### PR TITLE
MEED-302 Fix Copy Address button action

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/ContractAddress.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/ContractAddress.vue
@@ -99,7 +99,9 @@ export default {
   },
   methods: {
     copyToClipboard() {
-      document.getElementById('copyToClipboardInput').select();
+      const copyToClipboardInput = document.getElementById('copyToClipboardInput');
+      copyToClipboardInput.value = this.address;
+      copyToClipboardInput.select();
       if (document.execCommand) {
         try {
           document.execCommand('copy');


### PR DESCRIPTION
Prior to this change, when copying the address using UI, the value added into clipboard is always the same. This change will make sure to copy the displayed address instead of current user wallet address.