### PR TITLE
MEED-364 Fix maximum value of ether

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/TradeMeeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/TradeMeeds.vue
@@ -374,7 +374,12 @@ export default {
     },
     setMaxValue() {
       if (this.buy) {
-        this.fromValue = this.$ethUtils.fromDecimals(this.etherBalance.sub(this.transactionGas), 18);
+        const remainingEtherValue = this.$ethUtils.fromDecimals(this.etherBalance.sub(this.transactionGas), 18);
+        if (remainingEtherValue > 0) {
+          this.fromValue = remainingEtherValue;
+        } else {
+          this.fromValue = 0;
+        }
       } else {
         this.fromValue = this.$ethUtils.fromDecimals(this.meedsBalance, 18);
       }


### PR DESCRIPTION
Prior to this change, when clicking on the max icon to buy meeds with ether, an incorrect value was displayed in negative form. This change will adjust to the correct maximum value of ether.