### PR TITLE
MEED-284 Add circulating supply public endpoint 

### DIFF
--- a/deeds-dapp-common/src/test/java/io/meeds/deeds/blockchain/BlockchainConfigurationPropertiesTest.java
+++ b/deeds-dapp-common/src/test/java/io/meeds/deeds/blockchain/BlockchainConfigurationPropertiesTest.java
@@ -29,17 +29,26 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
         "meeds.blockchain.networkUrl=" + BlockchainConfigurationPropertiesTest.NETWORK_URL_VALUE,
+        "meeds.blockchain.polygonNetworkUrl=" + BlockchainConfigurationPropertiesTest.POLYGON_NETWORK_URL_VALUE,
         "meeds.blockchain.tenantProvisioningAddress=" + BlockchainConfigurationPropertiesTest.TENANT_PROVISIONING_ADDRESS_VALUE,
         "meeds.blockchain.deedAddress=" + BlockchainConfigurationPropertiesTest.DEED_ADDRESS_VALUE,
+        "meeds.blockchain.meedAddress=" + BlockchainConfigurationPropertiesTest.MAINNET_MEED_ADDRESS_VALUE,
+        "meeds.blockchain.polygonMeedAddress=" + BlockchainConfigurationPropertiesTest.POLYGON_MEED_ADDRESS_VALUE,
     }
 )
 class BlockchainConfigurationPropertiesTest {
 
   public static final String                NETWORK_URL_VALUE                 = "NETWORK_URL";
 
+  public static final String                POLYGON_NETWORK_URL_VALUE         = "POLYGON_NETWORK_URL";
+
   public static final String                TENANT_PROVISIONING_ADDRESS_VALUE = "TENANT_PROVISIONING_ADDRESS";
 
   public static final String                DEED_ADDRESS_VALUE                = "DEED_ADDRESS";
+
+  public static final String                MAINNET_MEED_ADDRESS_VALUE        = "MAINNET_MEED_ADDRESS";
+
+  public static final String                POLYGON_MEED_ADDRESS_VALUE        = "POLYGON_MEED_ADDRESS";
 
   @Autowired
   private BlockchainConfigurationProperties blockchainConfigurationProperties;
@@ -48,12 +57,18 @@ class BlockchainConfigurationPropertiesTest {
   void testProperties() {
     assertNotNull(blockchainConfigurationProperties);
     assertEquals(NETWORK_URL_VALUE, blockchainConfigurationProperties.getNetworkUrl());
+    assertEquals(POLYGON_NETWORK_URL_VALUE, blockchainConfigurationProperties.getPolygonNetworkUrl());
     assertEquals(TENANT_PROVISIONING_ADDRESS_VALUE, blockchainConfigurationProperties.getTenantProvisioningAddress());
     assertEquals(DEED_ADDRESS_VALUE, blockchainConfigurationProperties.getDeedAddress());
+    assertEquals(MAINNET_MEED_ADDRESS_VALUE, blockchainConfigurationProperties.getMeedAddress());
+    assertEquals(POLYGON_MEED_ADDRESS_VALUE, blockchainConfigurationProperties.getPolygonMeedAddress());
 
     BlockchainConfigurationProperties properties = new BlockchainConfigurationProperties(NETWORK_URL_VALUE,
+                                                                                         POLYGON_NETWORK_URL_VALUE,
                                                                                          TENANT_PROVISIONING_ADDRESS_VALUE,
-                                                                                         DEED_ADDRESS_VALUE);
+                                                                                         DEED_ADDRESS_VALUE,
+                                                                                         MAINNET_MEED_ADDRESS_VALUE,
+                                                                                         POLYGON_MEED_ADDRESS_VALUE);
     assertEquals(properties, blockchainConfigurationProperties);
     assertEquals(properties.hashCode(), blockchainConfigurationProperties.hashCode());
     assertEquals(properties.toString(), blockchainConfigurationProperties.toString());

--- a/deeds-dapp-service/pom.xml
+++ b/deeds-dapp-service/pom.xml
@@ -58,8 +58,38 @@
       <artifactId>rxjava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.wallet</groupId>
+      <artifactId>ert-contract</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>tuples</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>abi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.web3j</groupId>
       <artifactId>crypto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>rlp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/model/MeedTokenMetric.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/model/MeedTokenMetric.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.deeds.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.Setting.SortOrder;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "meed_token_metrics", createIndex = true)
+@Setting(
+    sortFields = "date",
+    sortOrders = SortOrder.desc,
+    replicas = 0,
+    shards = 1
+)
+public class MeedTokenMetric {
+
+  public MeedTokenMetric(LocalDate date) {
+    this.date = date;
+  }
+
+  @Id
+  @Field(type = FieldType.Date, format = DateFormat.year_month_day)
+  private LocalDate               date;
+
+  private BigDecimal              totalSupply;
+
+  private Map<String, BigDecimal> lockedBalances;
+
+  private Map<String, BigDecimal> reserveBalances;
+
+  private BigDecimal              circulatingSupply;
+
+  private BigDecimal              marketCapitalization;
+
+  private BigDecimal              totalValuelocked;
+
+  private BigDecimal              meedUsdPrice;
+
+}

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/SchedulingConfig.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/SchedulingConfig.java
@@ -1,8 +1,8 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * 
+ *
  * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -11,13 +11,14 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package io.meeds.deeds.scheduling;
 
+import io.meeds.deeds.scheduling.task.MeedTokenMetricTask;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -37,6 +38,11 @@ public class SchedulingConfig {
   @Bean
   public MeedsExchangeTask meedsExchangeTask() {
     return new MeedsExchangeTask();
+  }
+
+  @Bean
+  public MeedTokenMetricTask meedsTokenMetricTask() {
+    return new MeedTokenMetricTask();
   }
 
 }

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/MeedTokenMetricTask.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/MeedTokenMetricTask.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.deeds.scheduling.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import io.meeds.deeds.service.MeedTokenMetricService;
+
+public class MeedTokenMetricTask {
+
+  private static final Logger    LOG = LoggerFactory.getLogger(MeedTokenMetricTask.class);
+
+  @Autowired
+  private MeedTokenMetricService meedTokenMetricService;
+
+  @Scheduled(cron = "0 0/30 * * * *")
+  public synchronized void computeMeedTokenMetrics() {
+    LOG.info("Start Computing circulating supply");
+    long start = System.currentTimeMillis();
+    try {
+      meedTokenMetricService.computeTokenMetrics();
+      LOG.info("End Computing circulating supply in {}ms", System.currentTimeMillis() - start);
+    } catch (Exception e) {
+      LOG.warn("An error occurred while computing circulating supply", e);
+    }
+  }
+
+}

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/BlockchainService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/BlockchainService.java
@@ -15,29 +15,45 @@
  */
 package io.meeds.deeds.service;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import io.meeds.deeds.constant.ObjectNotFoundException;
 import io.meeds.deeds.contract.Deed;
+import io.meeds.deeds.contract.MeedsToken;
 import io.meeds.deeds.contract.TenantProvisioningStrategy;
 
 @Component
 public class BlockchainService {
 
-  @Autowired
   private TenantProvisioningStrategy tenantProvisioningStrategy;
 
-  @Autowired
   private Deed                       deed;
+
+  private MeedsToken                 ethereumToken;
+
+  private MeedsToken                 polygonToken;
+
+  public BlockchainService(TenantProvisioningStrategy tenantProvisioningStrategy,
+                           Deed deed,
+                           @Qualifier("ethereumMeedToken")
+                           MeedsToken ethereumToken,
+                           @Qualifier("polygonMeedToken")
+                           MeedsToken polygonToken) {
+    this.tenantProvisioningStrategy = tenantProvisioningStrategy;
+    this.deed = deed;
+    this.ethereumToken = ethereumToken;
+    this.polygonToken = polygonToken;
+  }
 
   /**
    * Retrieves from blockchain whether an address is the provisioning manager of
    * the deed or not
-   * 
+   *
    * @param address Ethereum address to check
    * @param nftId Deed NFT identifier
    * @return true if is manager else false
@@ -56,7 +72,7 @@ public class BlockchainService {
    * - 1 : Uncommon
    * - 2 : Rare
    * - 3 : Legendary
-   * 
+   *
    * @param nftId Deed NFT identifier
    * @return card type index
    * @throws ObjectNotFoundException when NFT with selected identifier doesn't
@@ -83,7 +99,7 @@ public class BlockchainService {
    * - 4 : Eshmun
    * - 5 : Kushor
    * - 6 : Hammon
-   * 
+   *
    * @param nftId Deed NFT identifier
    * @return card city index
    * @throws ObjectNotFoundException when NFT with selected identifier doesn't
@@ -98,6 +114,54 @@ public class BlockchainService {
       } else {
         throw new IllegalStateException("Error retrieving information 'getDeedCityIndex' from Blockchain", e);
       }
+    }
+  }
+
+  /**
+   * @return {@link BigDecimal} representing the total supply of Meeds Token
+   *           which is retrieved from ethereum blockchain. The retrieved value
+   *           is divided by number of decimals of the token (10^18)
+   */
+  public BigDecimal totalSupply() {
+    try {
+      BigInteger totalSupply = ethereumToken.totalSupply().send();
+      return new BigDecimal(totalSupply).divide(BigDecimal.valueOf(10).pow(18));
+    } catch (Exception e) {
+      throw new IllegalStateException("Error retrieving total supply for MEED Token on Ethereum at address "
+          + ethereumToken.getContractAddress(),
+                                      e);
+    }
+  }
+
+  /**
+   * @param address Ethereum address
+   * @return {@link BigDecimal} representing the balance of address
+   *           which is retrieved from ethereum blockchain. The retrieved value
+   *           is divided by number of decimals of the token (10^18)
+   */
+  public BigDecimal balanceOfOnEthereum(String address) {
+    try {
+      BigInteger balance = ethereumToken.balanceOf(address).send();
+      return new BigDecimal(balance).divide(BigDecimal.valueOf(10).pow(18));
+    } catch (Exception e) {
+      throw new IllegalStateException("Error retrieving information 'balanceOf(" + address + ")' on Ethereum Blockchain",
+                                      e);
+    }
+  }
+
+  /**
+   * @param address Ethereum address
+   * @return {@link BigDecimal} representing the balance of address
+   *           which is retrieved from polygon blockchain. The retrieved value
+   *           is divided by number of decimals of the token (10^18)
+   */
+  public BigDecimal balanceOfOnPolygon(String address) {
+    try {
+      BigInteger balance = polygonToken.balanceOf(address).send();
+      return new BigDecimal(balance).divide(BigDecimal.valueOf(10).pow(18));
+    } catch (Exception e) {
+      throw new IllegalStateException("Error retrieving information 'balanceOf(" + address + ")' from Polygon Blockchain",
+                                      e);
     }
   }
 

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -118,14 +119,18 @@ public class MeedTokenMetricService {
    */
   public Map<String, BigDecimal> getReserveBalances() {
     Map<String, BigDecimal> reserveBalances = new HashMap<>();
-    reserveEthereumAddresses.stream().forEach(address -> {
-      BigDecimal balance = blockchainService.balanceOfOnEthereum(address);
-      reserveBalances.put(address.toLowerCase(), balance);
-    });
-    reservePolygonAddresses.stream().forEach(address -> {
-      BigDecimal balance = blockchainService.balanceOfOnPolygon(address);
-      reserveBalances.put(address.toLowerCase(), balance);
-    });
+    reserveEthereumAddresses.stream()
+                            .filter(StringUtils::isNotBlank)
+                            .forEach(address -> {
+                              BigDecimal balance = blockchainService.balanceOfOnEthereum(address);
+                              reserveBalances.put(address.toLowerCase(), balance);
+                            });
+    reservePolygonAddresses.stream()
+                           .filter(StringUtils::isNotBlank)
+                           .forEach(address -> {
+                             BigDecimal balance = blockchainService.balanceOfOnPolygon(address);
+                             reserveBalances.put(address.toLowerCase(), balance);
+                           });
     return reserveBalances;
   }
 
@@ -136,14 +141,18 @@ public class MeedTokenMetricService {
    */
   public Map<String, BigDecimal> getLockedBalances() {
     Map<String, BigDecimal> lockedBalances = new HashMap<>();
-    lockedEthereumAddresses.stream().forEach(address -> {
-      BigDecimal balance = blockchainService.balanceOfOnEthereum(address);
-      lockedBalances.put(address.toLowerCase(), balance);
-    });
-    lockedPolygonAddresses.stream().forEach(address -> {
-      BigDecimal balance = blockchainService.balanceOfOnPolygon(address);
-      lockedBalances.put(address.toLowerCase(), balance);
-    });
+    lockedEthereumAddresses.stream()
+                           .filter(StringUtils::isNotBlank)
+                           .forEach(address -> {
+                             BigDecimal balance = blockchainService.balanceOfOnEthereum(address);
+                             lockedBalances.put(address.toLowerCase(), balance);
+                           });
+    lockedPolygonAddresses.stream()
+                          .filter(StringUtils::isNotBlank)
+                          .forEach(address -> {
+                            BigDecimal balance = blockchainService.balanceOfOnPolygon(address);
+                            lockedBalances.put(address.toLowerCase(), balance);
+                          });
     return lockedBalances;
   }
 

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.deeds.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.meeds.deeds.model.MeedTokenMetric;
+import io.meeds.deeds.storage.MeedTokenMetricsRepository;
+import lombok.Getter;
+
+@Component
+public class MeedTokenMetricService {
+
+  @Value(
+    "#{'${meeds.blockchain.reserveValueEthereumAddresses:0xBa5e4D55CA96bf25c35Fc65D9251355Dcd120655,0x8f4660498E79c771f93316f09da98E1eBF94c576,0x70CAd5d439591Ea7f496B69DcB22521685015853}'.split(',')}"
+  )
+  @Getter
+  private List<String>               reserveEthereumAddresses;
+
+  @Value(
+    "#{'${meeds.blockchain.reserveValuePolygonAddresses:}'.split(',')}"
+  )
+  @Getter
+  private List<String>               reservePolygonAddresses;
+
+  @Value(
+    "#{'${meeds.blockchain.lockedValueEthereumAddresses:0x44D6d6aB50401Dd846336e9C706A492f06E1Bcd4,0x960Bd61D0b960B107fF5309A2DCceD4705567070}'.split(',')}"
+  )
+  @Getter
+  private List<String>               lockedEthereumAddresses;
+
+  @Value("#{'${meeds.blockchain.lockedValuePolygonAddresses:0x6acA77CF3BaB0C4E8210A09B57B07854a995289a}'.split(',')}")
+  @Getter
+  private List<String>               lockedPolygonAddresses;
+
+  @Autowired(required = false)
+  private BlockchainService          blockchainService;
+
+  @Autowired
+  private MeedTokenMetricsRepository meedTokenMetricsRepository;
+
+  @Getter
+  private MeedTokenMetric            recentMetric;
+
+  /**
+   * Retrieves list of total circulating Meeds supply by using this formula:
+   * - Total supply of Meeds - total Meeds reserves - total locked Meeds
+   * 
+   * @return {@link BigDecimal} for most recent computed circulating supply
+   *           value
+   */
+  public BigDecimal getCirculatingSupply() {
+    if (recentMetric == null) {
+      recentMetric = getTodayMetric();
+      if (recentMetric == null) {
+        computeTokenMetrics();
+      }
+    }
+    return recentMetric.getCirculatingSupply();
+  }
+
+  /**
+   * Retrieves Metrics of Meed Token from Blockchain and other external sources.
+   * Once retrieved, it will be saved. The metrics are collected by day, in
+   * other terms, there will be only one metric entity collected by a day.
+   */
+  public void computeTokenMetrics() {
+    MeedTokenMetric metric = getTodayMetric();
+    if (metric == null) {
+      metric = new MeedTokenMetric(getTodayId());
+    }
+    BigDecimal totalSupply = blockchainService.totalSupply();
+    metric.setTotalSupply(totalSupply);
+
+    Map<String, BigDecimal> reserveBalances = getReserveBalances();
+    metric.setReserveBalances(reserveBalances);
+
+    Map<String, BigDecimal> lockedBalances = getLockedBalances();
+    metric.setLockedBalances(lockedBalances);
+
+    BigDecimal reserveValue = reserveBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
+    BigDecimal lockedValue = lockedBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
+    BigDecimal circulatingSupply = totalSupply.subtract(reserveValue).subtract(lockedValue);
+    metric.setCirculatingSupply(circulatingSupply);
+
+    meedTokenMetricsRepository.save(metric);
+
+    // Cache most recent collected Metric
+    this.recentMetric = metric;
+  }
+
+  /**
+   * @return {@link Map} of {@link String} and {@link BigDecimal}. This will
+   *           retrieve from Ethereum and Polygon Blockchains a Map of Token
+   *           balances for each configured reserveBalanceAddress.
+   */
+  public Map<String, BigDecimal> getReserveBalances() {
+    Map<String, BigDecimal> reserveBalances = new HashMap<>();
+    reserveEthereumAddresses.stream().forEach(address -> {
+      BigDecimal balance = blockchainService.balanceOfOnEthereum(address);
+      reserveBalances.put(address.toLowerCase(), balance);
+    });
+    reservePolygonAddresses.stream().forEach(address -> {
+      BigDecimal balance = blockchainService.balanceOfOnPolygon(address);
+      reserveBalances.put(address.toLowerCase(), balance);
+    });
+    return reserveBalances;
+  }
+
+  /**
+   * @return {@link Map} of {@link String} and {@link BigDecimal}. This will
+   *           retrieve from Ethereum and Polygon Blockchains a Map of Token
+   *           balances for each configured lockedBalanceAddress.
+   */
+  public Map<String, BigDecimal> getLockedBalances() {
+    Map<String, BigDecimal> lockedBalances = new HashMap<>();
+    lockedEthereumAddresses.stream().forEach(address -> {
+      BigDecimal balance = blockchainService.balanceOfOnEthereum(address);
+      lockedBalances.put(address.toLowerCase(), balance);
+    });
+    lockedPolygonAddresses.stream().forEach(address -> {
+      BigDecimal balance = blockchainService.balanceOfOnPolygon(address);
+      lockedBalances.put(address.toLowerCase(), balance);
+    });
+    return lockedBalances;
+  }
+
+  private MeedTokenMetric getTodayMetric() {
+    return meedTokenMetricsRepository.findById(getTodayId()).orElse(null);
+  }
+
+  private LocalDate getTodayId() {
+    return LocalDate.now(ZoneOffset.UTC);
+  }
+
+}

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/storage/MeedTokenMetricsRepository.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/storage/MeedTokenMetricsRepository.java
@@ -13,32 +13,14 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package io.meeds.deeds.blockchain;
+package io.meeds.deeds.storage;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import java.time.LocalDate;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-@Configuration
-@ConfigurationProperties(prefix = "meeds.blockchain")
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class BlockchainConfigurationProperties {
+import io.meeds.deeds.model.MeedTokenMetric;
 
-  private String networkUrl;
-
-  private String polygonNetworkUrl;
-
-  private String tenantProvisioningAddress;
-
-  private String deedAddress;
-
-  private String meedAddress;
-
-  private String polygonMeedAddress;
+public interface MeedTokenMetricsRepository extends ElasticsearchRepository<MeedTokenMetric, LocalDate> {
 
 }

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.deeds.web.rest;
+
+import java.math.BigDecimal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.meeds.deeds.service.MeedTokenMetricService;
+
+@RestController
+@RequestMapping("/api/token/meed")
+public class MeedTokenMetricController {
+
+  @Autowired
+  private MeedTokenMetricService meedTokenMetricService;
+
+  @GetMapping("/circ")
+  public ResponseEntity<BigDecimal> getCirculatingSupply() {
+    BigDecimal circulatingSupply = meedTokenMetricService.getCirculatingSupply();
+    return ResponseEntity.ok()
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(circulatingSupply);
+  }
+
+}

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricTest.java
@@ -1,0 +1,184 @@
+
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.deeds.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import io.meeds.deeds.contract.MeedsToken;
+import io.meeds.deeds.model.MeedTokenMetric;
+import io.meeds.deeds.storage.MeedTokenMetricsRepository;
+
+@SpringBootTest(
+    classes = {
+        MeedTokenMetricService.class,
+    }
+)
+@TestPropertySource(
+    properties = {
+        "meeds.blockchain.reserveValueEthereumAddresses=0xBa5e4D55CA96bf25c35Fc65D9251355Dcd120655,0x8f4660498E79c771f93316f09da98E1eBF94c576,0x70CAd5d439591Ea7f496B69DcB22521685015853",
+        "meeds.blockchain.reserveValuePolygonAddresses=0x44D6d6aB50401Dd846336e9C706A492f06E1Bee4",
+        "meeds.blockchain.lockedValueEthereumAddresses=0x44D6d6aB50401Dd846336e9C706A492f06E1Bcd4,0x960Bd61D0b960B107fF5309A2DCceD4705567070",
+        "meeds.blockchain.lockedValuePolygonAddresses=0x6acA77CF3BaB0C4E8210A09B57B07854a995289a"
+    }
+)
+class MeedTokenMetricTest {
+
+  @MockBean
+  private BlockchainService          blockchainService;
+
+  @MockBean
+  private MeedTokenMetric            metric;
+
+  @MockBean
+  private MeedTokenMetricsRepository meedTokenMetricsRepository;
+
+  @MockBean(name = "ethereumMeedToken")
+  private MeedsToken                 ethereumToken;
+
+  @MockBean(name = "polygonMeedToken")
+  private MeedsToken                 polygonToken;
+
+  @Autowired
+  private MeedTokenMetricService     meedTokenMetricService;
+
+  @BeforeEach
+  void init() {
+    reset(meedTokenMetricsRepository);
+  }
+
+  @Test
+  void testGetReserveBalances() {
+    Map<String, BigDecimal> expectedReserveBalances = new HashMap<>();
+    BigDecimal totalReserves = mockReserveBalances(expectedReserveBalances);
+    Map<String, BigDecimal> reserveBalances = meedTokenMetricService.getReserveBalances();
+    assertEquals(expectedReserveBalances, reserveBalances);
+
+    BigDecimal result = reserveBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
+    assertEquals(totalReserves, result);
+  }
+
+  @Test
+  void testGetLockedBalances() {
+    Map<String, BigDecimal> expectedLockedBalances = new HashMap<>();
+    BigDecimal totallocked = mockLockedBalances(expectedLockedBalances);
+    Map<String, BigDecimal> lockedBalances = meedTokenMetricService.getLockedBalances();
+    assertEquals(expectedLockedBalances, lockedBalances);
+
+    BigDecimal result = lockedBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
+    assertEquals(totallocked, result);
+  }
+
+  @Test
+  void testComputeTokenMetrics() {
+    // Given
+    BigDecimal expectedTotalSupply = BigDecimal.valueOf(100);
+    when(blockchainService.totalSupply()).thenReturn(expectedTotalSupply);
+
+    HashMap<String, BigDecimal> expectedReserveBalances = new HashMap<>();
+    BigDecimal expectedTotalReserves = mockReserveBalances(expectedReserveBalances);
+    HashMap<String, BigDecimal> expectedLockedBalances = new HashMap<>();
+    BigDecimal expectedTotalLocked = mockLockedBalances(expectedLockedBalances);
+
+    BigDecimal expectedCirculatingSupply = expectedTotalSupply.subtract(expectedTotalReserves).subtract(expectedTotalLocked);
+
+    // When
+    meedTokenMetricService.computeTokenMetrics();
+
+    // Then
+    MeedTokenMetric recentMetric = meedTokenMetricService.getRecentMetric();
+    assertNotNull(recentMetric);
+    assertEquals(expectedTotalSupply, recentMetric.getTotalSupply());
+    assertEquals(expectedReserveBalances, recentMetric.getReserveBalances());
+    assertEquals(expectedLockedBalances, recentMetric.getLockedBalances());
+    assertEquals(expectedCirculatingSupply, recentMetric.getCirculatingSupply());
+
+    verify(meedTokenMetricsRepository, times(1)).save(recentMetric);
+  }
+
+  @Test
+  void testGetCirculatingSupply() {
+    // Given
+    BigDecimal expectedTotalSupply = BigDecimal.valueOf(100);
+    when(blockchainService.totalSupply()).thenReturn(expectedTotalSupply);
+
+    BigDecimal expectedTotalReserves = mockReserveBalances(new HashMap<>());
+    BigDecimal expectedTotalLocked = mockLockedBalances(new HashMap<>());
+    BigDecimal expectedCirculatingSupply = expectedTotalSupply.subtract(expectedTotalReserves).subtract(expectedTotalLocked);
+
+    // When
+    meedTokenMetricService.computeTokenMetrics();
+
+    // Then
+    BigDecimal circulatingSupply = meedTokenMetricService.getCirculatingSupply();
+    assertEquals(expectedCirculatingSupply, circulatingSupply);
+  }
+
+  private BigDecimal mockReserveBalances(Map<String, BigDecimal> expectedReserveBalances) {
+    BigDecimal totalReserves = new BigDecimal(0);
+    for (String address : meedTokenMetricService.getReserveEthereumAddresses()) {
+      double value = Math.random() * 1000;
+      BigDecimal valueBigDecimal = BigDecimal.valueOf(value);
+      when(blockchainService.balanceOfOnEthereum(address)).thenReturn(valueBigDecimal);
+      expectedReserveBalances.put(address.toLowerCase(), valueBigDecimal);
+      totalReserves = totalReserves.add(valueBigDecimal);
+    }
+    for (String address : meedTokenMetricService.getReservePolygonAddresses()) {
+      double value = Math.random() * 1000;
+      BigDecimal valueBigDecimal = BigDecimal.valueOf(value);
+      when(blockchainService.balanceOfOnPolygon(address)).thenReturn(valueBigDecimal);
+      expectedReserveBalances.put(address.toLowerCase(), valueBigDecimal);
+      totalReserves = totalReserves.add(valueBigDecimal);
+    }
+    return totalReserves;
+  }
+
+  private BigDecimal mockLockedBalances(Map<String, BigDecimal> expectedLockedBalances) {
+    BigDecimal totallocked = new BigDecimal(0);
+    for (String address : meedTokenMetricService.getLockedEthereumAddresses()) {
+      double value = Math.random() * 1000;
+      BigDecimal valueBigDecimal = BigDecimal.valueOf(value);
+      when(blockchainService.balanceOfOnEthereum(address)).thenReturn(valueBigDecimal);
+      expectedLockedBalances.put(address.toLowerCase(), valueBigDecimal);
+      totallocked = totallocked.add(valueBigDecimal);
+    }
+    for (String address : meedTokenMetricService.getLockedPolygonAddresses()) {
+      double value = Math.random() * 1000;
+      BigDecimal valueBigDecimal = BigDecimal.valueOf(value);
+      when(blockchainService.balanceOfOnPolygon(address)).thenReturn(valueBigDecimal);
+      expectedLockedBalances.put(address.toLowerCase(), valueBigDecimal);
+      totallocked = totallocked.add(valueBigDecimal);
+    }
+    return totallocked;
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <commons-io.version>2.9.0</commons-io.version>
     <org.web3j.version>4.8.9</org.web3j.version>
     <com.squareup.okhttp3.version>4.9.0</com.squareup.okhttp3.version>
+    <org.exoplatform.wallet.ert-contract.version>1.3.x-SNAPSHOT</org.exoplatform.wallet.ert-contract.version>
 
     <!-- Get latest version of Surefire to enable JUnit 5 -->
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
@@ -70,6 +71,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.exoplatform.wallet</groupId>
+        <artifactId>ert-contract</artifactId>
+        <version>${org.exoplatform.wallet.ert-contract.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.web3j</groupId>
         <artifactId>core</artifactId>
         <version>${org.web3j.version}</version>
@@ -77,6 +84,26 @@
       <dependency>
         <groupId>org.web3j</groupId>
         <artifactId>crypto</artifactId>
+        <version>${org.web3j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.web3j</groupId>
+        <artifactId>utils</artifactId>
+        <version>${org.web3j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.web3j</groupId>
+        <artifactId>abi</artifactId>
+        <version>${org.web3j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.web3j</groupId>
+        <artifactId>rlp</artifactId>
+        <version>${org.web3j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.web3j</groupId>
+        <artifactId>tuples</artifactId>
         <version>${org.web3j.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This change will introduce a new REST endpoint to retrieve circulating supply of Meeds Token. This endpoint can be used and consulted from other third party exchange sites.
