### PR TITLE
MEED-291 Add Market Capitalization public endpoint

### DIFF
--- a/deeds-dapp-service/pom.xml
+++ b/deeds-dapp-service/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>deeds-dapp-service</artifactId>
   <name>Meeds:: Deeds Dapp - Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.42</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.44</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -41,4 +41,12 @@ public class MeedTokenMetricController {
                          .body(circulatingSupply);
   }
 
+  @GetMapping("/mcap")
+  public ResponseEntity<BigDecimal> getMarketCapitalization() {
+    BigDecimal marketCapitalization = meedTokenMetricService.getMarketCapitalization();
+    return ResponseEntity.ok()
+            .cacheControl(CacheControl.noCache().cachePublic())
+            .body(marketCapitalization);
+  }
+
 }


### PR DESCRIPTION
This change will introduce a new REST endpoint to retrieve market capitalization of Meeds Token. This endpoint can be used and consulted from other third party exchange sites.