### PR TITLE
MEED-292 Add Total Locked Value public endpoint

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -188,7 +188,7 @@ public class MeedTokenMetricService {
     return lockedBalances;
   }
 
-  public BigDecimal getTotalLockedBalance(Map<String, BigDecimal> lockedBalances) {
+  private BigDecimal getTotalLockedBalance(Map<String, BigDecimal> lockedBalances) {
     return lockedBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
   }
 

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -21,6 +21,7 @@ import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -189,11 +190,19 @@ public class MeedTokenMetricService {
   }
 
   private BigDecimal getTotalLockedBalance(Map<String, BigDecimal> lockedBalances) {
-    return lockedBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
+    return lockedBalances.values()
+                         .stream()
+                         .filter(Objects::nonNull)
+                         .reduce(BigDecimal::add)
+                         .orElse(BigDecimal.valueOf(0));
   }
 
   private BigDecimal getTotalReserveBalance(Map<String, BigDecimal> reserveBalances) {
-    return reserveBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
+    return reserveBalances.values()
+                          .stream()
+                          .filter(Objects::nonNull)
+                          .reduce(BigDecimal::add)
+                          .orElse(BigDecimal.valueOf(0));
   }
 
   private MeedTokenMetric getLastMetric() {

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -99,7 +99,7 @@ public class MeedTokenMetricService {
    * @return {@link BigDecimal} for most recent computed Total Locked Value
    *           value
    */
-  public BigDecimal getTotalValuelocked() {
+  public BigDecimal getTotalValueLocked() {
     MeedTokenMetric lastMetric = getLastMetric();
     return lastMetric.getTotalValuelocked();
   }

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -192,7 +192,7 @@ public class MeedTokenMetricService {
     return lockedBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
   }
 
-  public BigDecimal getTotalReserveBalance(Map<String, BigDecimal> reserveBalances) {
+  private BigDecimal getTotalReserveBalance(Map<String, BigDecimal> reserveBalances) {
     return reserveBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.valueOf(0));
   }
 

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -49,4 +49,12 @@ public class MeedTokenMetricController {
             .body(marketCapitalization);
   }
 
+  @GetMapping("/tvl")
+  public ResponseEntity<BigDecimal> getTotalLockedValue() {
+    BigDecimal marketCapitalization = meedTokenMetricService.getTotalValuelocked();
+    return ResponseEntity.ok()
+            .cacheControl(CacheControl.noCache().cachePublic())
+            .body(marketCapitalization);
+  }
+
 }

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -51,10 +51,10 @@ public class MeedTokenMetricController {
 
   @GetMapping("/tvl")
   public ResponseEntity<BigDecimal> getTotalLockedValue() {
-    BigDecimal marketCapitalization = meedTokenMetricService.getTotalValuelocked();
+    BigDecimal totalValueLocked = meedTokenMetricService.getTotalValueLocked();
     return ResponseEntity.ok()
             .cacheControl(CacheControl.noCache().cachePublic())
-            .body(marketCapitalization);
+            .body(totalValueLocked);
   }
 
 }

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -115,7 +115,7 @@ class MeedTokenMetricServiceTest {
     when(blockchainService.totalSupply()).thenReturn(expectedTotalSupply);
     when(exchangeService.getMeedUsdPrice()).thenReturn(meedPrice);
     meedTokenMetricService.computeTokenMetrics();
-    BigDecimal totalLockedValue = meedTokenMetricService.getTotalValuelocked();
+    BigDecimal totalLockedValue = meedTokenMetricService.getTotalValueLocked();
 
     //then
     assertEquals(expectedTotalLockedValue,totalLockedValue);

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -102,31 +102,11 @@ class MeedTokenMetricServiceTest {
   }
 
   @Test
-  void testGetTotalLockedBalance() {
-    Map<String, BigDecimal> lockedBalances = new HashMap<>();
-    mockLockedBalances(lockedBalances);
-
-    BigDecimal expectedTotalLockedBalance = BigDecimal.ZERO;
-    for (BigDecimal lockedBalance : lockedBalances.values()) {
-      expectedTotalLockedBalance = expectedTotalLockedBalance.add(lockedBalance);
-    }
-
-    BigDecimal totalLockedBalance = meedTokenMetricService.getTotalLockedBalance(lockedBalances);
-
-    assertEquals(expectedTotalLockedBalance, totalLockedBalance);
-  }
-
-  @Test
   void testGetTotalLockedValue() {
     //Given
-    Map<String, BigDecimal> lockedBalances = new HashMap<>();
     Map<String, BigDecimal> reserveBalances = new HashMap<>();
-    mockLockedBalances(lockedBalances);
     mockReserveBalances(reserveBalances);
-    BigDecimal totalLockedBalance = BigDecimal.ZERO;
-    for (BigDecimal lockedBalance : lockedBalances.values()) {
-      totalLockedBalance = totalLockedBalance.add(lockedBalance);
-    }
+    BigDecimal totalLockedBalance = mockLockedBalances(new HashMap<>());
     BigDecimal meedPrice = BigDecimal.valueOf(19);
     BigDecimal expectedTotalLockedValue = meedPrice.multiply(totalLockedBalance);
 

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -102,6 +102,47 @@ class MeedTokenMetricServiceTest {
   }
 
   @Test
+  void testGetTotalLockedBalance() {
+    Map<String, BigDecimal> lockedBalances = new HashMap<>();
+    mockLockedBalances(lockedBalances);
+
+    BigDecimal expectedTotalLockedBalance = BigDecimal.ZERO;
+    for (BigDecimal lockedBalance : lockedBalances.values()) {
+      expectedTotalLockedBalance = expectedTotalLockedBalance.add(lockedBalance);
+    }
+
+    BigDecimal totalLockedBalance = meedTokenMetricService.getTotalLockedBalance(lockedBalances);
+
+    assertEquals(expectedTotalLockedBalance, totalLockedBalance);
+  }
+
+  @Test
+  void testGetTotalLockedValue() {
+    //Given
+    Map<String, BigDecimal> lockedBalances = new HashMap<>();
+    Map<String, BigDecimal> reserveBalances = new HashMap<>();
+    mockLockedBalances(lockedBalances);
+    mockReserveBalances(reserveBalances);
+    BigDecimal totalLockedBalance = BigDecimal.ZERO;
+    for (BigDecimal lockedBalance : lockedBalances.values()) {
+      totalLockedBalance = totalLockedBalance.add(lockedBalance);
+    }
+    BigDecimal meedPrice = BigDecimal.valueOf(19);
+    BigDecimal expectedTotalLockedValue = meedPrice.multiply(totalLockedBalance);
+
+    //when
+    BigDecimal expectedTotalSupply = BigDecimal.valueOf(100);
+    when(blockchainService.totalSupply()).thenReturn(expectedTotalSupply);
+    when(exchangeService.getMeedUsdPrice()).thenReturn(meedPrice);
+    meedTokenMetricService.computeTokenMetrics();
+    BigDecimal totalLockedValue = meedTokenMetricService.getTotalValuelocked();
+
+    //then
+    assertEquals(expectedTotalLockedValue,totalLockedValue);
+
+  }
+
+  @Test
   void testComputeTokenMetrics() {
     // Given
     BigDecimal expectedTotalSupply = BigDecimal.valueOf(100);

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -104,8 +104,6 @@ class MeedTokenMetricServiceTest {
   @Test
   void testGetTotalLockedValue() {
     //Given
-    Map<String, BigDecimal> reserveBalances = new HashMap<>();
-    mockReserveBalances(reserveBalances);
     BigDecimal totalLockedBalance = mockLockedBalances(new HashMap<>());
     BigDecimal meedPrice = BigDecimal.valueOf(19);
     BigDecimal expectedTotalLockedValue = meedPrice.multiply(totalLockedBalance);

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -139,7 +139,6 @@ class MeedTokenMetricServiceTest {
 
     //then
     assertEquals(expectedTotalLockedValue,totalLockedValue);
-
   }
 
   @Test


### PR DESCRIPTION
This change will introduce a new REST endpoint to retrieve Total Locked Value of Meeds Token. This endpoint can be used and consulted from other third party exchange sites.