### PR TITLE
MEED-292 Add Total Locked Value public endpoint

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -49,4 +49,12 @@ public class MeedTokenMetricController {
             .body(marketCapitalization);
   }
 
+  @GetMapping("/tvl")
+  public ResponseEntity<BigDecimal> getTotalLockedValue() {
+    BigDecimal totalValueLocked = meedTokenMetricService.getTotalValueLocked();
+    return ResponseEntity.ok()
+            .cacheControl(CacheControl.noCache().cachePublic())
+            .body(totalValueLocked);
+  }
+
 }

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -102,6 +102,24 @@ class MeedTokenMetricServiceTest {
   }
 
   @Test
+  void testGetTotalLockedValue() {
+    //Given
+    BigDecimal totalLockedBalance = mockLockedBalances(new HashMap<>());
+    BigDecimal meedPrice = BigDecimal.valueOf(19);
+    BigDecimal expectedTotalLockedValue = meedPrice.multiply(totalLockedBalance);
+
+    //when
+    BigDecimal expectedTotalSupply = BigDecimal.valueOf(100);
+    when(blockchainService.totalSupply()).thenReturn(expectedTotalSupply);
+    when(exchangeService.getMeedUsdPrice()).thenReturn(meedPrice);
+    meedTokenMetricService.computeTokenMetrics();
+    BigDecimal totalLockedValue = meedTokenMetricService.getTotalValueLocked();
+
+    //then
+    assertEquals(expectedTotalLockedValue,totalLockedValue);
+  }
+
+  @Test
   void testComputeTokenMetrics() {
     // Given
     BigDecimal expectedTotalSupply = BigDecimal.valueOf(100);


### PR DESCRIPTION
This change will introduce a new REST endpoint to retrieve Total Locked Value of Meeds Token. This endpoint can be used and consulted from other third party exchange sites.