### PR TITLE
MEED-431: add total supply public endpoint 

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -16,7 +16,6 @@
 package io.meeds.deeds.service;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -90,8 +89,7 @@ public class MeedTokenMetricService {
    */
   public BigDecimal getTotalSupply() {
     MeedTokenMetric lastMetric = getLastMetric();
-    BigDecimal totalSupply = lastMetric.getTotalSupply();
-    return totalSupply.setScale(8, RoundingMode.CEILING);
+    return lastMetric.getTotalSupply();
   }
 
   /**

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -16,6 +16,7 @@
 package io.meeds.deeds.service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -72,13 +73,25 @@ public class MeedTokenMetricService {
   /**
    * Retrieves total circulating Meeds supply by using this formula:
    * - Total supply of Meeds - total Meeds reserves - total locked Meeds
-   * 
+   *
    * @return {@link BigDecimal} for most recent computed circulating supply
    *           value
    */
   public BigDecimal getCirculatingSupply() {
     MeedTokenMetric lastMetric = getLastMetric();
     return lastMetric.getCirculatingSupply();
+  }
+
+  /**
+   * Retrieves total Meeds supply, reading the value of the ERC20.totalSupply() Meeds contract
+   *
+   * @return {@link BigDecimal} for most recent computed total supply
+   *           value
+   */
+  public BigDecimal getTotalSupply() {
+    MeedTokenMetric lastMetric = getLastMetric();
+    BigDecimal totalSupply = lastMetric.getTotalSupply();
+    return totalSupply.setScale(8, RoundingMode.CEILING);
   }
 
   /**

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -45,24 +45,24 @@ public class MeedTokenMetricController {
   public ResponseEntity<BigDecimal> getMarketCapitalization() {
     BigDecimal marketCapitalization = meedTokenMetricService.getMarketCapitalization();
     return ResponseEntity.ok()
-            .cacheControl(CacheControl.noCache().cachePublic())
-            .body(marketCapitalization);
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(marketCapitalization);
   }
 
   @GetMapping("/tvl")
   public ResponseEntity<BigDecimal> getTotalLockedValue() {
     BigDecimal totalValueLocked = meedTokenMetricService.getTotalValueLocked();
     return ResponseEntity.ok()
-            .cacheControl(CacheControl.noCache().cachePublic())
-            .body(totalValueLocked);
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(totalValueLocked);
   }
 
   @GetMapping("/supply")
   public ResponseEntity<BigDecimal> getTotalSupply() {
     BigDecimal totalSupply = meedTokenMetricService.getTotalSupply();
     return ResponseEntity.ok()
-            .cacheControl(CacheControl.noCache().cachePublic())
-            .body(totalSupply);
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(totalSupply);
   }
 
 }

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -57,7 +57,7 @@ public class MeedTokenMetricController {
             .body(totalValueLocked);
   }
 
-  @GetMapping("/total")
+  @GetMapping("/supply")
   public ResponseEntity<BigDecimal> getTotalSupply() {
     BigDecimal totalSupply = meedTokenMetricService.getTotalSupply();
     return ResponseEntity.ok()

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -57,4 +57,12 @@ public class MeedTokenMetricController {
             .body(totalValueLocked);
   }
 
+  @GetMapping("/total")
+  public ResponseEntity<BigDecimal> getTotalSupply() {
+    BigDecimal totalSupply = meedTokenMetricService.getTotalSupply();
+    return ResponseEntity.ok()
+            .cacheControl(CacheControl.noCache().cachePublic())
+            .body(totalSupply);
+  }
+
 }

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -18,10 +18,7 @@ package io.meeds.deeds.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -88,6 +85,14 @@ class MeedTokenMetricServiceTest {
 
     BigDecimal result = reserveBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
     assertEquals(totalReserves, result);
+  }
+
+  @Test
+  void testGetTotalSupply() {
+    // Given the wanted format with 8 decimals
+    BigDecimal totalSupply = BigDecimal.valueOf(100.00000000);
+    when(blockchainService.totalSupply()).thenReturn(totalSupply);
+    assertEquals(totalSupply, meedTokenMetricService.getTotalSupply());
   }
 
   @Test

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -18,7 +18,10 @@ package io.meeds.deeds.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -57,9 +60,6 @@ class MeedTokenMetricServiceTest {
   private ExchangeService            exchangeService;
 
   @MockBean
-  private MeedTokenMetric            metric;
-
-  @MockBean
   private MeedTokenMetricsRepository meedTokenMetricsRepository;
 
   @MockBean(name = "ethereumMeedToken")
@@ -89,9 +89,12 @@ class MeedTokenMetricServiceTest {
 
   @Test
   void testGetTotalSupply() {
-    // Given the wanted format with 8 decimals
-    BigDecimal totalSupply = BigDecimal.valueOf(100.00000000);
+    BigDecimal totalSupply = BigDecimal.valueOf(1997.190119975555D);
     when(blockchainService.totalSupply()).thenReturn(totalSupply);
+
+    when(exchangeService.getMeedUsdPrice()).thenReturn(BigDecimal.ZERO);
+    meedTokenMetricService.computeTokenMetrics();
+
     assertEquals(totalSupply, meedTokenMetricService.getTotalSupply());
   }
 


### PR DESCRIPTION
This change will introduce a new REST endpoint to retrieve Total Supply Value of Meeds Token. This endpoint can be used and consulted from other third party exchange sites.