### PR TITLE
MEED-431 add total supply public endpoint

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/MeedTokenMetricService.java
@@ -72,13 +72,24 @@ public class MeedTokenMetricService {
   /**
    * Retrieves total circulating Meeds supply by using this formula:
    * - Total supply of Meeds - total Meeds reserves - total locked Meeds
-   * 
+   *
    * @return {@link BigDecimal} for most recent computed circulating supply
    *           value
    */
   public BigDecimal getCirculatingSupply() {
     MeedTokenMetric lastMetric = getLastMetric();
     return lastMetric.getCirculatingSupply();
+  }
+
+  /**
+   * Retrieves total Meeds supply, reading the value of the ERC20.totalSupply() Meeds contract
+   *
+   * @return {@link BigDecimal} for most recent computed total supply
+   *           value
+   */
+  public BigDecimal getTotalSupply() {
+    MeedTokenMetric lastMetric = getLastMetric();
+    return lastMetric.getTotalSupply();
   }
 
   /**

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -45,16 +45,24 @@ public class MeedTokenMetricController {
   public ResponseEntity<BigDecimal> getMarketCapitalization() {
     BigDecimal marketCapitalization = meedTokenMetricService.getMarketCapitalization();
     return ResponseEntity.ok()
-            .cacheControl(CacheControl.noCache().cachePublic())
-            .body(marketCapitalization);
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(marketCapitalization);
   }
 
   @GetMapping("/tvl")
   public ResponseEntity<BigDecimal> getTotalLockedValue() {
     BigDecimal totalValueLocked = meedTokenMetricService.getTotalValueLocked();
     return ResponseEntity.ok()
-            .cacheControl(CacheControl.noCache().cachePublic())
-            .body(totalValueLocked);
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(totalValueLocked);
+  }
+
+  @GetMapping("/supply")
+  public ResponseEntity<BigDecimal> getTotalSupply() {
+    BigDecimal totalSupply = meedTokenMetricService.getTotalSupply();
+    return ResponseEntity.ok()
+                         .cacheControl(CacheControl.noCache().cachePublic())
+                         .body(totalSupply);
   }
 
 }

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/service/MeedTokenMetricServiceTest.java
@@ -60,9 +60,6 @@ class MeedTokenMetricServiceTest {
   private ExchangeService            exchangeService;
 
   @MockBean
-  private MeedTokenMetric            metric;
-
-  @MockBean
   private MeedTokenMetricsRepository meedTokenMetricsRepository;
 
   @MockBean(name = "ethereumMeedToken")
@@ -88,6 +85,17 @@ class MeedTokenMetricServiceTest {
 
     BigDecimal result = reserveBalances.values().stream().reduce(BigDecimal::add).orElse(BigDecimal.ZERO);
     assertEquals(totalReserves, result);
+  }
+
+  @Test
+  void testGetTotalSupply() {
+    BigDecimal totalSupply = BigDecimal.valueOf(1997.190119975555D);
+    when(blockchainService.totalSupply()).thenReturn(totalSupply);
+
+    when(exchangeService.getMeedUsdPrice()).thenReturn(BigDecimal.ZERO);
+    meedTokenMetricService.computeTokenMetrics();
+
+    assertEquals(totalSupply, meedTokenMetricService.getTotalSupply());
   }
 
   @Test


### PR DESCRIPTION
This change will introduce a new `REST endpoint` to retrieve `Total Supply Value of Meeds Token`. This endpoint can be used and consulted from other `third party exchange sites`.