### PR TITLE
MEED-375 Watch language for the internationalization of pie chart labels

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
@@ -18,7 +18,7 @@
 -->
 <template>
   <div class="d-flex flex-column">
-    <deeds-assets  />
+    <deeds-assets />
     <deeds-meeds-info />
   </div>
 </template>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
@@ -30,6 +30,7 @@ export default {
     xMeedAddress: state => state.xMeedAddress,
     comethPairAddress: state => state.comethPairAddress,
     vestingAddress: state => state.vestingAddress,
+    language: state => state.language,
     chartOptions() {
       const chartData = [];
       if (this.metrics) {
@@ -91,6 +92,11 @@ export default {
   }),
   watch: {
     metrics() {
+      if (this.chart && this.chartOptions) {
+        this.chart.setOption(this.chartOptions);
+      }
+    },
+    language() {
       if (this.chart && this.chartOptions) {
         this.chart.setOption(this.chartOptions);
       }


### PR DESCRIPTION
Prior to this change, the pie chart labels were not instantly i18Ned when switching to French language, the user had to refresh the page to get the internalized labels. 
This change solves this problem.