### PR TITLE
MEED-451 Use a narrow format symbol

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/js/ethUtils.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/js/ethUtils.js
@@ -114,6 +114,7 @@ export function toCurrencyDisplay(value, currency, lang) {
   return new Intl.NumberFormat(lang || 'en', {
     style: 'currency',
     currency,
+    currencyDisplay: 'narrowSymbol',
     minimumFractionDigits: 0,
     maximumFractionDigits: currency === 'eth' && 8 || 2,
   }).format(value || 0).replace(/(\..*[1-9])0+$/, '$1').replace(/\.0*$/, '');


### PR DESCRIPTION
Prior to this change, the MEED price shown in the investor application was displayed with an incorrect symbol when using the French language.
This change corrects this issue by adding a narrow option for the symbol format.