### PR TITLE
MEED-467 Watch language for internationalization of xAxis line graph labels

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/PriceChart.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/PriceChart.vue
@@ -167,6 +167,11 @@ export default {
         this.refreshData();
       }
     },
+    language() {
+      if (this.chart && this.chartOptions) {
+        this.chart.setOption(this.chartOptions);
+      }
+    },
     selectedFiatCurrency(newVal, oldVal) {
       if (newVal && newVal !== oldVal) {
         this.refreshData();


### PR DESCRIPTION
Prior to this change, the xAxis line graph labels were not internalized instantly when the language was changed, the user had to refresh the page to get the correct labels.
This change resolves this issue.