### PR TITLE
MEED-373 Add LP Token assets details in overview page

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/static/css/deeds.css
+++ b/deeds-dapp-webapp/src/main/webapp/static/css/deeds.css
@@ -124,5 +124,5 @@ html {
 }
 
 .assets {
-  width: 500px;
+  width: 1000px;
 }

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/Farm.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/Farm.vue
@@ -26,7 +26,7 @@
 <script>
 export default {
   created() {
-    this.$store.commit('loadRewardedFunds');
+    this.$store.commit('loadRewardedFunds', true);
   },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPools.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPools.vue
@@ -19,10 +19,21 @@
 <template>
   <v-container class="mt-2">
     <v-row class="mx-auto" no-gutters>
-      <template v-if="rewardedFunds">
+      <template v-if="loading">
+        <v-col
+          v-for="i in poolCount"
+          :key="i">
+          <v-skeleton-loader
+            type="card"
+            class="mx-auto ma-2"
+            width="400px"
+            max-width="100%" />
+        </v-col>
+      </template>
+      <template v-else>
         <v-col
           v-for="pool in rewardedPools"
-          :key="pool.address">
+          :key="`${pool.address}_${pool.refresh}`">
           <deeds-liquidity-pool :pool="pool" />
         </v-col>
         <v-col key="cometh">
@@ -49,17 +60,6 @@
           </deeds-liquidity-pool>
         </v-col>
       </template>
-      <template v-else>
-        <v-col
-          v-for="i in 2"
-          :key="i">
-          <v-skeleton-loader
-            type="card"
-            class="mx-auto ma-2"
-            width="400px"
-            max-width="100%" />
-        </v-col>
-      </template>
     </v-row>
   </v-container>
 </template>
@@ -69,8 +69,12 @@ export default {
     rentComethLiquidityLink: state => state.rentComethLiquidityLink,
     parentLocation: state => state.parentLocation,
     rewardedFunds: state => state.rewardedFunds,
-    rewardedPools() {
-      return this.rewardedFunds && this.rewardedFunds.filter(fund => fund.isLPToken);
+    rewardedPools: state => state.rewardedPools,
+    poolCount() {
+      return this.rewardedPools && this.rewardedPools.length || 2;
+    },
+    loading() {
+      return !this.rewardedPools || this.rewardedPools.filter(pool => pool.loading).length > 0;
     },
   }),
 };

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
@@ -520,7 +520,7 @@ const store = new Vuex.Store({
         })
         .finally(() => {
           pool.loading = false;
-
+          // Force reloading list of pools after updated
           const index = state.rewardedPools.findIndex(tmpPool => tmpPool === pool);
           state.rewardedPools.splice(index, 1, pool);
         });

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
@@ -267,7 +267,7 @@ const store = new Vuex.Store({
               state.tokenFactoryAddress = '0x1B37D04759aD542640Cc44Ff849a373040386050';
               state.xMeedAddress = '0x44d6d6ab50401dd846336e9c706a492f06e1bcd4';
               state.deedAddress = '0x0143b71443650aa8efa76bd82f35c22ebd558090';
-              state.comethPairAddress = '0xb82F8457fcf644803f4D74F677905F1d410Cd395';
+              state.univ2PairAddress = '0xb82F8457fcf644803f4D74F677905F1d410Cd395';
               state.vestingAddress = '0x440701ca5817b5847438da2ec2ca3b9fdbf37dfa';
               state.tenantProvisioningAddress = null;
 
@@ -506,6 +506,20 @@ const store = new Vuex.Store({
           state.xMeedContract = new ethers.Contract(
             state.xMeedAddress,
             state.xMeedRewardingABI,
+            state.provider
+          );
+        }
+        if (state.sushiswapPairAddress) {
+          state.sushiswapPairContract = new ethers.Contract(
+            state.sushiswapPairAddress,
+            state.erc20ABI,
+            state.provider
+          );
+        }
+        if (state.univ2PairAddress) {
+          state.univ2PairContract = new ethers.Contract(
+            state.univ2PairAddress,
+            state.erc20ABI,
             state.provider
           );
         }

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
@@ -22,3 +22,10 @@
     <deeds-meeds-info />
   </div>
 </template>
+<script>
+export default {
+  created() {
+    this.$store.commit('loadRewardedFunds', true);
+  },
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
@@ -17,18 +17,16 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-list-item v-if="existBalance" class="ps-8">
-    <v-list-item-content class="align-start">
-      <div>
-        <deeds-contract-address
-          :address="lpAddress"
-          :label="poolName"
-          token />
-      </div>
-    </v-list-item-content>
-    <v-list-item-content class="align-end">
+  <deeds-token-asset-template>
+    <template #col1>
+      <deeds-contract-address
+        :address="lpAddress"
+        :label="poolName"
+        token />
+    </template>
+    <template #col2>
       <v-skeleton-loader
-        v-if="loadingBalance"
+        v-if="loadingUserInfo"
         type="chip"
         max-height="17"
         tile />
@@ -39,56 +37,53 @@
             v-bind="attrs"
             v-on="on">
             <deeds-number-format
-              :value="lpBalance"
+              :value="lpStaked"
               :fractions="2" />
-            <span class="mx-1"> {{ lpSymbol }}  </span>
+            <span class="mx-1 text-no-wrap"> {{ lpSymbol }}  </span>
           </div>
         </template>
         <span v-if="noMeedSupplyForLPRemaining">
           {{ $t('maxMeedsSupplyReached') }}
         </span>
-        <div v-if="rewardsStarted" class="d-flex flex-row">
-          <span class="mx-1"> {{ $t('apy') }} </span>
+        <div class="d-flex flex-row">
+          <span class="mx-1 text-no-wrap"> {{ $t('apy') }} </span>
           <deeds-number-format
             :value="apy"
             no-decimals>
             %
           </deeds-number-format>
         </div>
-        <div v-else>
-          {{ $t('meedsRewardingDidntStarted') }}
-        </div>
       </v-tooltip>
-    </v-list-item-content>
-    <v-list-item-content class="align-end">
+    </template>
+    <template #col3>
       <v-skeleton-loader
-        v-if="loadingXMeedsBalance"
+        v-if="loading"
         type="chip"
         max-height="17"
         tile /> 
       <div 
         v-else
-        class="d-flex">
+        class="d-flex flex-row flex-nowrap">
         <span class="mx-1">+</span>
         <deeds-number-format 
           :value="weeklyRewardedMeeds" 
           :fractions="2" />
-        <span class="mx-1">MEED / {{ $t('week') }}</span>
+        <span class="mx-1 text-no-wrap">MEED / {{ $t('week') }}</span>
       </div>
-    </v-list-item-content>
-    <v-list-item-content class="align-end">
+    </template>
+    <template #col4>
       <v-skeleton-loader
-        v-if="loadingBalance"
+        v-if="loadingUserInfo"
         type="chip"
         max-height="17"
         tile />
       <deeds-number-format
         v-else
-        :value="lpBalance"
+        :value="lpStaked"
         :fractions="2"
         currency />
-    </v-list-item-content>
-  </v-list-item>
+    </template>
+  </deeds-token-asset-template>
 </template>
 <script>
 export default {
@@ -98,66 +93,14 @@ export default {
       default: null,
     },
   },
-  data: () => ({
-    userInfo: null,
-    loadingBalance: true,
-    loadingUserInfo: false,
-    lpSymbol: null,
-    yearInMinutes: 365 * 24 * 60,
-    yearInWeeks: 7 / 365,
-    meedsBalanceOfPool: null,
-    lpBalanceOfTokenFactory: null,
-    lpTotalSupply: null,
-    lpBalance: null
-  }),
   computed: Vuex.mapState({
     sushiswapPairAddress: state => state.sushiswapPairAddress,
     univ2PairAddress: state => state.univ2PairAddress,
-    address: state => state.address,
-    provider: state => state.provider,
-    erc20ABI: state => state.erc20ABI,
-    tokenFactoryContract: state => state.tokenFactoryContract,
-    farmingStartTime: state => state.farmingStartTime,
-    now: state => state.now,
-    rewardedMeedPerMinute: state => state.rewardedMeedPerMinute,
-    rewardedTotalAllocationPoints: state => state.rewardedTotalAllocationPoints,
-    rewardedTotalFixedPercentage: state => state.rewardedTotalFixedPercentage,
-    meedContract: state => state.meedContract,
-    tokenFactoryAddress: state => state.tokenFactoryAddress,
-    noMeedSupplyForLPRemaining: state => state.noMeedSupplyForLPRemaining,
-    univ2PairContract: state => state.univ2PairContract,
-    sushiswapPairContract: state => state.sushiswapPairContract,
-    lpAddress() {
-      return this.pool && this.pool.address;
-    },
-    lpStaked() {
-      return this.userInfo && this.userInfo.amount || 0;
-    },
-    lpContract() {
-      if (this.lpAddress && this.lpAddress.toLowerCase() === this.sushiswapPairAddress.toLowerCase()) {
-        return this.sushiswapPairContract;
-      } else if (this.lpAddress && this.lpAddress.toLowerCase() === this.univ2PairAddress.toLowerCase()) {
-        return this.univ2PairContract;
-      }
-      return null;
-    },
-    lpContractBalanceOf() {
-      return this.lpContract && this.lpContract.balanceOf;
-    },
-    lpContractTotalSupply() {
-      return this.lpContract && this.lpContract.totalSupply;
-    },
     isSushiswapPool() {
       return this.sushiswapPairAddress && this.pool && this.pool.address && this.pool.address.toUpperCase() === this.sushiswapPairAddress.toUpperCase();
     },
     isUniswapPool() {
       return this.univ2PairAddress && this.pool && this.pool.address && this.pool.address.toUpperCase() === this.univ2PairAddress.toUpperCase();
-    },
-    tokenFactoryUserLpInfos() {
-      if (this.provider && this.tokenFactoryContract) {
-        return this.tokenFactoryContract.userLpInfos;
-      }
-      return null;
     },
     poolName() {
       if (this.isSushiswapPool) {
@@ -167,175 +110,34 @@ export default {
       }
       return this.lpSymbol;
     },
-    meedContractBalanceOf() {
-      if (this.provider && this.meedContract) {
-        return this.meedContract.balanceOf;
-      }
-      return null;
+    lpAddress() {
+      return this.pool && this.pool.address;
     },
-    lpContractSymbol() {
-      return this.lpContract && this.lpContract.symbol;
+    lpSymbol() {
+      return this.pool && this.pool.symbol;
     },
-    rewardsStarted() {
-      return this.farmingStartTime < this.now;
+    userInfo() {
+      return this.pool && this.pool.userInfo;
     },
-    yearlyRewardedMeeds() {
-      if (this.pool && this.lpAddress) {
-        if (this.pool.fixedPercentage && !this.pool.fixedPercentage.isZero()) {
-          return new BigNumber(this.rewardedMeedPerMinute.toString())
-            .multipliedBy(this.yearInMinutes)
-            .multipliedBy(this.pool.fixedPercentage.toString())
-            .dividedBy(100);
-        } else if (this.pool.allocationPoint && !this.pool.allocationPoint.isZero()) {
-          return new BigNumber(this.rewardedMeedPerMinute.toString())
-            .multipliedBy(this.yearInMinutes)
-            .multipliedBy(this.pool.allocationPoint.toString())
-            .dividedBy(this.rewardedTotalAllocationPoints.toString())
-            .dividedBy(100)
-            .multipliedBy(100 - this.rewardedTotalFixedPercentage.toNumber());
-        }
-      }
-      return new BigNumber(0);
+    lpStaked() {
+      return this.userInfo && this.userInfo.amount || 0;
     },
-    stakedEquivalentMeedsBalanceOfPool() {
-      return this.meedsBalanceOfPool
-        && this.lpBalanceOfTokenFactory
-        && this.lpTotalSupply
-        && !this.lpTotalSupply.isZero()
-        && this.meedsBalanceOfPool.mul(this.lpBalanceOfTokenFactory).mul(2).div(this.lpTotalSupply);
+    loadingUserInfo() {
+      return this.pool && this.pool.loadingUserInfo;
+    },
+    loading() {
+      return this.pool && this.pool.loading;
     },
     apy() {
-      if (!this.stakedEquivalentMeedsBalanceOfPool
-          || !this.yearlyRewardedMeeds
-          || !this.rewardsStarted
-          || this.stakedEquivalentMeedsBalanceOfPool.isZero()
-          || this.noMeedSupplyForLPRemaining
-          || this.yearlyRewardedMeeds.isZero()
-          || !this.rewardsStarted) {
-        return 0;
-      }
-      return this.yearlyRewardedMeeds.dividedBy(this.stakedEquivalentMeedsBalanceOfPool.toString()).multipliedBy(100);
+      return this.pool && this.pool.apy;
     },
     weeklyRewardedMeeds() {
-      if (this.lpStaked && this.apy) {
-        return new BigNumber(this.lpStaked.toString())
-          .multipliedBy(this.apy.toString())
-          .dividedBy(100)
-          .multipliedBy(this.yearInWeeks);
-      }
+      return new BigNumber(this.lpStaked.toString())
+        .multipliedBy(this.apy.toString())
+        .dividedBy(100)
+        .multipliedBy(7)
+        .dividedBy(365);
     },
-    existBalance() {
-      return this.lpBalance > 0;
-    }
   }),
-  watch: {
-    tokenFactoryUserLpInfos: {
-      immadiate: true,
-      handler() {
-        if (this.lpAddress && this.tokenFactoryUserLpInfos) {
-          this.refreshUserInfo();
-        }
-      }
-    },
-    lpContractSymbol: {
-      immadiate: true,
-      handler() {
-        if (this.lpAddress && this.lpContractSymbol) {
-          this.refreshLPSymbol();
-        }
-      },
-    },
-    meedContractBalanceOf: {
-      immadiate: true,
-      handler() {
-        if (this.lpAddress && this.meedContractBalanceOf && !this.meedsBalanceOfPool) {
-          this.refreshMeedsBalanceOfPool();
-        }
-      },
-    },
-    lpContractTotalSupply: {
-      immadiate: true,
-      handler() {
-        if (this.lpAddress && this.lpContractTotalSupply && !this.lpTotalSupply) {
-          this.refreshLPTotalSupply();
-        }
-      },
-    },
-    lpContractBalanceOf: {
-      immadiate: true,
-      handler() {
-        if (this.lpAddress && this.lpContractBalanceOf && !this.lpBalance) {
-          this.refreshLPBalance();
-        }
-      },
-    },
-  },
-  methods: {
-    refreshUserInfo() {
-      this.loadingUserInfo = true;
-      this.tokenFactoryUserLpInfos(this.lpAddress, this.address)
-        .then(userInfo => {
-          const user = {};
-          Object.keys(userInfo).forEach(key => {
-            if (Number.isNaN(Number(key))) {
-              user[key] = userInfo[key];
-            }
-          });
-          this.userInfo = user;
-          return user;
-        })
-        .finally(() => this.loadingUserInfo = false);
-    },
-    refreshLPSymbol() {
-      this.loadingBalance = true;
-      this.lpContractSymbol()
-        .then(symbol => this.lpSymbol = symbol)
-        .finally(() => this.loadingBalance = false);
-    },
-    refreshMeedsBalanceOfPool() {
-      this.loadingBalance = true;
-      this.meedContractBalanceOf(this.lpAddress)
-        .then(balance => this.meedsBalanceOfPool = balance)
-        .finally(() => this.loadingBalance = false);
-    },
-    refreshTokenFactoryBalance() {
-      this.loadingBalance = true;
-      this.lpContractBalanceOf(this.tokenFactoryAddress)
-        .then(balance => this.lpBalanceOfTokenFactory = balance)
-        .finally(() => this.loadingBalance = false);
-    },
-    refreshLPTotalSupply() {
-      this.loadingBalance = true;
-      this.lpContractTotalSupply()
-        .then(totalSupply => this.lpTotalSupply = totalSupply)
-        .finally(() => this.loadingBalance = false);
-    },
-    refreshLPBalance() {
-      this.loadingBalance = true;
-      this.lpContractBalanceOf(this.address)
-        .then(balance => this.lpBalance = balance)
-        .finally(() => this.loadingBalance = false);
-    },
-  },
-  created() {
-    if (this.tokenFactoryUserLpInfos) {
-      this.refreshUserInfo();
-    }
-    if (this.lpContractSymbol) {
-      this.refreshLPSymbol();
-    }
-    if (this.meedContractBalanceOf && !this.meedsBalanceOfPool) {
-      this.refreshMeedsBalanceOfPool();
-    }
-    if (this.tokenFactoryAddress) {
-      this.refreshTokenFactoryBalance();
-    }
-    if (this.lpContractTotalSupply && !this.lpTotalSupply) {
-      this.refreshLPTotalSupply();
-    }
-    if (this.lpContractBalanceOf && !this.lpBalance) {
-      this.refreshLPBalance();
-    }    
-  },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
@@ -1,0 +1,341 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-list-item v-if="existBalance" class="ps-8">
+    <v-list-item-content class="align-start">
+      <div>
+        <deeds-contract-address
+          :address="lpAddress"
+          :label="poolName"
+          token />
+      </div>
+    </v-list-item-content>
+    <v-list-item-content class="align-end">
+      <v-skeleton-loader
+        v-if="loadingBalance"
+        type="chip"
+        max-height="17"
+        tile />
+      <v-tooltip v-else bottom>
+        <template #activator="{ on, attrs }">
+          <div
+            class="d-flex flex-nowrap"
+            v-bind="attrs"
+            v-on="on">
+            <deeds-number-format
+              :value="lpBalance"
+              :fractions="2" />
+            <span class="mx-1"> {{ lpSymbol }}  </span>
+          </div>
+        </template>
+        <span v-if="noMeedSupplyForLPRemaining">
+          {{ $t('maxMeedsSupplyReached') }}
+        </span>
+        <div v-if="rewardsStarted" class="d-flex flex-row">
+          <span class="mx-1"> {{ $t('apy') }} </span>
+          <deeds-number-format
+            :value="apy"
+            no-decimals>
+            %
+          </deeds-number-format>
+        </div>
+        <div v-else>
+          {{ $t('meedsRewardingDidntStarted') }}
+        </div>
+      </v-tooltip>
+    </v-list-item-content>
+    <v-list-item-content class="align-end">
+      <v-skeleton-loader
+        v-if="loadingXMeedsBalance"
+        type="chip"
+        max-height="17"
+        tile /> 
+      <div 
+        v-else
+        class="d-flex">
+        <span class="mx-1">+</span>
+        <deeds-number-format 
+          :value="weeklyRewardedMeeds" 
+          :fractions="2" />
+        <span class="mx-1">MEED / {{ $t('week') }}</span>
+      </div>
+    </v-list-item-content>
+    <v-list-item-content class="align-end">
+      <v-skeleton-loader
+        v-if="loadingBalance"
+        type="chip"
+        max-height="17"
+        tile />
+      <deeds-number-format
+        v-else
+        :value="lpBalance"
+        :fractions="2"
+        currency />
+    </v-list-item-content>
+  </v-list-item>
+</template>
+<script>
+export default {
+  props: {
+    pool: {
+      type: Object,
+      default: null,
+    },
+  },
+  data: () => ({
+    userInfo: null,
+    loadingBalance: true,
+    loadingUserInfo: false,
+    lpSymbol: null,
+    yearInMinutes: 365 * 24 * 60,
+    yearInWeeks: 7 / 365,
+    meedsBalanceOfPool: null,
+    lpBalanceOfTokenFactory: null,
+    lpTotalSupply: null,
+    lpBalance: null
+  }),
+  computed: Vuex.mapState({
+    sushiswapPairAddress: state => state.sushiswapPairAddress,
+    univ2PairAddress: state => state.univ2PairAddress,
+    address: state => state.address,
+    provider: state => state.provider,
+    erc20ABI: state => state.erc20ABI,
+    tokenFactoryContract: state => state.tokenFactoryContract,
+    farmingStartTime: state => state.farmingStartTime,
+    now: state => state.now,
+    rewardedMeedPerMinute: state => state.rewardedMeedPerMinute,
+    rewardedTotalAllocationPoints: state => state.rewardedTotalAllocationPoints,
+    rewardedTotalFixedPercentage: state => state.rewardedTotalFixedPercentage,
+    meedContract: state => state.meedContract,
+    tokenFactoryAddress: state => state.tokenFactoryAddress,
+    noMeedSupplyForLPRemaining: state => state.noMeedSupplyForLPRemaining,
+    univ2PairContract: state => state.univ2PairContract,
+    sushiswapPairContract: state => state.sushiswapPairContract,
+    lpAddress() {
+      return this.pool && this.pool.address;
+    },
+    lpStaked() {
+      return this.userInfo && this.userInfo.amount || 0;
+    },
+    lpContract() {
+      if (this.lpAddress && this.lpAddress.toLowerCase() === this.sushiswapPairAddress.toLowerCase()) {
+        return this.sushiswapPairContract;
+      } else if (this.lpAddress && this.lpAddress.toLowerCase() === this.univ2PairAddress.toLowerCase()) {
+        return this.univ2PairContract;
+      }
+      return null;
+    },
+    lpContractBalanceOf() {
+      return this.lpContract && this.lpContract.balanceOf;
+    },
+    lpContractTotalSupply() {
+      return this.lpContract && this.lpContract.totalSupply;
+    },
+    isSushiswapPool() {
+      return this.sushiswapPairAddress && this.pool && this.pool.address && this.pool.address.toUpperCase() === this.sushiswapPairAddress.toUpperCase();
+    },
+    isUniswapPool() {
+      return this.univ2PairAddress && this.pool && this.pool.address && this.pool.address.toUpperCase() === this.univ2PairAddress.toUpperCase();
+    },
+    tokenFactoryUserLpInfos() {
+      if (this.provider && this.tokenFactoryContract) {
+        return this.tokenFactoryContract.userLpInfos;
+      }
+      return null;
+    },
+    poolName() {
+      if (this.isSushiswapPool) {
+        return 'Sushiswap';
+      } else if (this.isUniswapPool) {
+        return 'Uniswap';
+      }
+      return this.lpSymbol;
+    },
+    meedContractBalanceOf() {
+      if (this.provider && this.meedContract) {
+        return this.meedContract.balanceOf;
+      }
+      return null;
+    },
+    lpContractSymbol() {
+      return this.lpContract && this.lpContract.symbol;
+    },
+    rewardsStarted() {
+      return this.farmingStartTime < this.now;
+    },
+    yearlyRewardedMeeds() {
+      if (this.pool && this.lpAddress) {
+        if (this.pool.fixedPercentage && !this.pool.fixedPercentage.isZero()) {
+          return new BigNumber(this.rewardedMeedPerMinute.toString())
+            .multipliedBy(this.yearInMinutes)
+            .multipliedBy(this.pool.fixedPercentage.toString())
+            .dividedBy(100);
+        } else if (this.pool.allocationPoint && !this.pool.allocationPoint.isZero()) {
+          return new BigNumber(this.rewardedMeedPerMinute.toString())
+            .multipliedBy(this.yearInMinutes)
+            .multipliedBy(this.pool.allocationPoint.toString())
+            .dividedBy(this.rewardedTotalAllocationPoints.toString())
+            .dividedBy(100)
+            .multipliedBy(100 - this.rewardedTotalFixedPercentage.toNumber());
+        }
+      }
+      return new BigNumber(0);
+    },
+    stakedEquivalentMeedsBalanceOfPool() {
+      return this.meedsBalanceOfPool
+        && this.lpBalanceOfTokenFactory
+        && this.lpTotalSupply
+        && !this.lpTotalSupply.isZero()
+        && this.meedsBalanceOfPool.mul(this.lpBalanceOfTokenFactory).mul(2).div(this.lpTotalSupply);
+    },
+    apy() {
+      if (!this.stakedEquivalentMeedsBalanceOfPool
+          || !this.yearlyRewardedMeeds
+          || !this.rewardsStarted
+          || this.stakedEquivalentMeedsBalanceOfPool.isZero()
+          || this.noMeedSupplyForLPRemaining
+          || this.yearlyRewardedMeeds.isZero()
+          || !this.rewardsStarted) {
+        return 0;
+      }
+      return this.yearlyRewardedMeeds.dividedBy(this.stakedEquivalentMeedsBalanceOfPool.toString()).multipliedBy(100);
+    },
+    weeklyRewardedMeeds() {
+      if (this.lpStaked && this.apy) {
+        return new BigNumber(this.lpStaked.toString())
+          .multipliedBy(this.apy.toString())
+          .dividedBy(100)
+          .multipliedBy(this.yearInWeeks);
+      }
+    },
+    existBalance() {
+      return this.lpBalance > 0;
+    }
+  }),
+  watch: {
+    tokenFactoryUserLpInfos: {
+      immadiate: true,
+      handler() {
+        if (this.lpAddress && this.tokenFactoryUserLpInfos) {
+          this.refreshUserInfo();
+        }
+      }
+    },
+    lpContractSymbol: {
+      immadiate: true,
+      handler() {
+        if (this.lpAddress && this.lpContractSymbol) {
+          this.refreshLPSymbol();
+        }
+      },
+    },
+    meedContractBalanceOf: {
+      immadiate: true,
+      handler() {
+        if (this.lpAddress && this.meedContractBalanceOf && !this.meedsBalanceOfPool) {
+          this.refreshMeedsBalanceOfPool();
+        }
+      },
+    },
+    lpContractTotalSupply: {
+      immadiate: true,
+      handler() {
+        if (this.lpAddress && this.lpContractTotalSupply && !this.lpTotalSupply) {
+          this.refreshLPTotalSupply();
+        }
+      },
+    },
+    lpContractBalanceOf: {
+      immadiate: true,
+      handler() {
+        if (this.lpAddress && this.lpContractBalanceOf && !this.lpBalance) {
+          this.refreshLPBalance();
+        }
+      },
+    },
+  },
+  methods: {
+    refreshUserInfo() {
+      this.loadingUserInfo = true;
+      this.tokenFactoryUserLpInfos(this.lpAddress, this.address)
+        .then(userInfo => {
+          const user = {};
+          Object.keys(userInfo).forEach(key => {
+            if (Number.isNaN(Number(key))) {
+              user[key] = userInfo[key];
+            }
+          });
+          this.userInfo = user;
+          return user;
+        })
+        .finally(() => this.loadingUserInfo = false);
+    },
+    refreshLPSymbol() {
+      this.loadingBalance = true;
+      this.lpContractSymbol()
+        .then(symbol => this.lpSymbol = symbol)
+        .finally(() => this.loadingBalance = false);
+    },
+    refreshMeedsBalanceOfPool() {
+      this.loadingBalance = true;
+      this.meedContractBalanceOf(this.lpAddress)
+        .then(balance => this.meedsBalanceOfPool = balance)
+        .finally(() => this.loadingBalance = false);
+    },
+    refreshTokenFactoryBalance() {
+      this.loadingBalance = true;
+      this.lpContractBalanceOf(this.tokenFactoryAddress)
+        .then(balance => this.lpBalanceOfTokenFactory = balance)
+        .finally(() => this.loadingBalance = false);
+    },
+    refreshLPTotalSupply() {
+      this.loadingBalance = true;
+      this.lpContractTotalSupply()
+        .then(totalSupply => this.lpTotalSupply = totalSupply)
+        .finally(() => this.loadingBalance = false);
+    },
+    refreshLPBalance() {
+      this.loadingBalance = true;
+      this.lpContractBalanceOf(this.address)
+        .then(balance => this.lpBalance = balance)
+        .finally(() => this.loadingBalance = false);
+    },
+  },
+  created() {
+    if (this.tokenFactoryUserLpInfos) {
+      this.refreshUserInfo();
+    }
+    if (this.lpContractSymbol) {
+      this.refreshLPSymbol();
+    }
+    if (this.meedContractBalanceOf && !this.meedsBalanceOfPool) {
+      this.refreshMeedsBalanceOfPool();
+    }
+    if (this.tokenFactoryAddress) {
+      this.refreshTokenFactoryBalance();
+    }
+    if (this.lpContractTotalSupply && !this.lpTotalSupply) {
+      this.refreshLPTotalSupply();
+    }
+    if (this.lpContractBalanceOf && !this.lpBalance) {
+      this.refreshLPBalance();
+    }    
+  },
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
@@ -1,0 +1,61 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-row class="ps-8 pe-4 ma-0 d-flex flex-column flex-sm-row flex-grow-1">
+    <v-col
+      v-if="!isMobile || $slots.col1"
+      class="px-0 pb-0 pb-sm-3 text-no-wrap"
+      align-self="start">
+      <slot name="col1"></slot>
+    </v-col>
+    <v-divider class="d-block d-sm-none" />
+    <v-col
+      v-if="!isMobile || $slots.col2"
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
+      cols="3">
+      <slot name="col2"></slot>
+      <template v-if="isMobile && $slots.col4">
+        <small class="d-flex text-no-wrap">
+          <slot name="col4"></slot>
+        </small>
+      </template>
+    </v-col>
+    <v-col
+      v-if="!isMobile || $slots.col3"
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
+      cols="4">
+      <slot name="col3"></slot>
+    </v-col>
+    <v-col
+      v-if="!isMobile && $slots.col4"
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
+      align-self="end">
+      <slot name="col4"></slot>
+    </v-col>
+  </v-row>
+</template>
+<script>
+export default {
+  computed: {
+    isMobile() {
+      return this.$vuetify && this.$vuetify.breakpoint && this.$vuetify.breakpoint.name === 'xs';
+    },
+  },
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
@@ -33,7 +33,7 @@ export default {
   computed: Vuex.mapState({
     sushiswapPairAddress: state => state.sushiswapPairAddress,
     xMeedAddress: state => state.xMeedAddress,
-    comethPairAddress: state => state.comethPairAddress,
+    univ2PairAddress: state => state.univ2PairAddress,
     vestingAddress: state => state.vestingAddress,
     language: state => state.language,
     chartOptions() {
@@ -42,7 +42,7 @@ export default {
         Object.keys(this.metrics.lockedBalances).forEach((address) => {
           let name;
           const lockedBalance = this.metrics.lockedBalances[address];
-          if (address.toLowerCase() === this.comethPairAddress.toLowerCase()) {
+          if (address.toLowerCase() === this.univ2PairAddress.toLowerCase()) {
             name = this.$t('comethPool');
           } else if (address.toLowerCase() === this.xMeedAddress.toLowerCase()) {
             name = this.$t('xMeedsStaked');

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
@@ -33,7 +33,7 @@ export default {
   computed: Vuex.mapState({
     sushiswapPairAddress: state => state.sushiswapPairAddress,
     xMeedAddress: state => state.xMeedAddress,
-    univ2PairAddress: state => state.univ2PairAddress,
+    comethPairAddress: state => state.comethPairAddress,
     vestingAddress: state => state.vestingAddress,
     language: state => state.language,
     chartOptions() {
@@ -42,13 +42,13 @@ export default {
         Object.keys(this.metrics.lockedBalances).forEach((address) => {
           let name;
           const lockedBalance = this.metrics.lockedBalances[address];
-          if (address.toLowerCase() === this.univ2PairAddress.toLowerCase()) {
+          if (address.toLowerCase() === this.comethPairAddress?.toLowerCase()) {
             name = this.$t('comethPool');
-          } else if (address.toLowerCase() === this.xMeedAddress.toLowerCase()) {
+          } else if (address.toLowerCase() === this.xMeedAddress?.toLowerCase()) {
             name = this.$t('xMeedsStaked');
-          } else if (address.toLowerCase() === this.sushiswapPairAddress.toLowerCase()) {
+          } else if (address.toLowerCase() === this.sushiswapPairAddress?.toLowerCase()) {
             name = this.$t('sushiSwapPool');
-          } else if (address.toLowerCase() === this.vestingAddress.toLowerCase()) {
+          } else if (address.toLowerCase() === this.vestingAddress?.toLowerCase()) {
             name = this.$t('vestedMeeds');
           } else {
             name = this.$t('others');

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
@@ -21,6 +21,7 @@ import PriceChart from './components/charts/PriceChart.vue';
 import TradeMeeds from './components/TradeMeeds.vue';
 import Assets from './components/Assets.vue';
 import TokenAssets from './components/assets/TokenAssets.vue';
+import TokenAssetTemplate from './components/assets/TokenAssetTemplate.vue';
 import TokenAsset from './components/assets/TokenAsset.vue';
 import DeedAssets from './components/assets/DeedAssets.vue';
 import MeedsInfo from './components/MeedsInfo.vue';
@@ -33,6 +34,7 @@ const components = {
   'deeds-assets': Assets,
   'deeds-token-assets': TokenAssets,
   'deeds-token-asset': TokenAsset,
+  'deeds-token-asset-template': TokenAssetTemplate,
   'deeds-deed-assets': DeedAssets,
   'deeds-meeds-info': MeedsInfo,
   'deeds-currencies-chart': CurrenciesChart,

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
@@ -21,6 +21,7 @@ import PriceChart from './components/charts/PriceChart.vue';
 import TradeMeeds from './components/TradeMeeds.vue';
 import Assets from './components/Assets.vue';
 import TokenAssets from './components/assets/TokenAssets.vue';
+import TokenAsset from './components/assets/TokenAsset.vue';
 import DeedAssets from './components/assets/DeedAssets.vue';
 import MeedsInfo from './components/MeedsInfo.vue';
 import CurrenciesChart from './components/charts/CurrenciesChart.vue';
@@ -31,6 +32,7 @@ const components = {
   'deeds-trade-meeds': TradeMeeds,
   'deeds-assets': Assets,
   'deeds-token-assets': TokenAssets,
+  'deeds-token-asset': TokenAsset,
   'deeds-deed-assets': DeedAssets,
   'deeds-meeds-info': MeedsInfo,
   'deeds-currencies-chart': CurrenciesChart,

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/Stake.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/Stake.vue
@@ -30,7 +30,7 @@
 <script>
 export default {
   created() {
-    this.$store.commit('loadRewardedFunds');
+    this.$store.commit('loadRewardedFunds', true);
   },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeMeeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeMeeds.vue
@@ -227,7 +227,6 @@
 export default {
   data: () => ({
     stake: true,
-    yearInMinutes: 365 * 24 * 60,
   }),
   computed: Vuex.mapState({
     meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,
@@ -246,6 +245,7 @@ export default {
     stakingStartTime: state => state.stakingStartTime,
     maxMeedSupplyReached: state => state.maxMeedSupplyReached,
     now: state => state.now,
+    yearInMinutes: state => state.yearInMinutes,
     xMeedRewardInfo() {
       return this.rewardedFunds && this.xMeedAddress && this.rewardedFunds.find(fund => fund.address.toUpperCase() === this.xMeedAddress.toUpperCase());
     },


### PR DESCRIPTION
Prior to this change, in the first section "Your assets", the tokens were displayed in a table with the value of the APY, the balance token and the amount in USD/EUR.
This change will present, the token with the address of the contract, the balance of this token that the user has (tooltiped with the APY), the gain value from staked tokens per week and the amount of the balance that the user had.