### PR TITLE
MEED-373 Add LP Token assets details in overview page

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/static/css/deeds.css
+++ b/deeds-dapp-webapp/src/main/webapp/static/css/deeds.css
@@ -124,5 +124,5 @@ html {
 }
 
 .assets {
-  width: 500px;
+  width: 1000px;
 }

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/Farm.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/Farm.vue
@@ -26,7 +26,7 @@
 <script>
 export default {
   created() {
-    this.$store.commit('loadRewardedFunds');
+    this.$store.commit('loadRewardedFunds', true);
   },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPools.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPools.vue
@@ -19,10 +19,21 @@
 <template>
   <v-container class="mt-2">
     <v-row class="mx-auto" no-gutters>
-      <template v-if="rewardedFunds">
+      <template v-if="loading">
+        <v-col
+          v-for="i in poolCount"
+          :key="i">
+          <v-skeleton-loader
+            type="card"
+            class="mx-auto ma-2"
+            width="400px"
+            max-width="100%" />
+        </v-col>
+      </template>
+      <template v-else>
         <v-col
           v-for="pool in rewardedPools"
-          :key="pool.address">
+          :key="`${pool.address}_${pool.refresh}`">
           <deeds-liquidity-pool :pool="pool" />
         </v-col>
         <v-col key="cometh">
@@ -49,17 +60,6 @@
           </deeds-liquidity-pool>
         </v-col>
       </template>
-      <template v-else>
-        <v-col
-          v-for="i in 2"
-          :key="i">
-          <v-skeleton-loader
-            type="card"
-            class="mx-auto ma-2"
-            width="400px"
-            max-width="100%" />
-        </v-col>
-      </template>
     </v-row>
   </v-container>
 </template>
@@ -69,8 +69,12 @@ export default {
     rentComethLiquidityLink: state => state.rentComethLiquidityLink,
     parentLocation: state => state.parentLocation,
     rewardedFunds: state => state.rewardedFunds,
-    rewardedPools() {
-      return this.rewardedFunds && this.rewardedFunds.filter(fund => fund.isLPToken);
+    rewardedPools: state => state.rewardedPools,
+    poolCount() {
+      return this.rewardedPools && this.rewardedPools.length || 2;
+    },
+    loading() {
+      return !this.rewardedPools || this.rewardedPools.filter(pool => pool.loading).length > 0;
     },
   }),
 };

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
@@ -79,6 +79,7 @@ const store = new Vuex.Store({
     whitepaperLink: 'https://mirror.xyz/meedsdao.eth/EDh9QfsuuIDNS0yKcQDtGdXc25vfkpnnKpc3RYUTJgc',
     managedNetworkIds: [1, 4],
     provider: null,
+    yearInMinutes: 365 * 24 * 60,
     erc20ABI: [
       'event Transfer(address indexed from, address indexed to, uint256 value)',
       'event Approval(address indexed owner, address indexed spender, uint256 value)',
@@ -228,6 +229,7 @@ const store = new Vuex.Store({
     rewardedMeedPerMinute: null,
     rewardedFundsLength: null,
     rewardedFunds: null,
+    rewardedPools: null,
     rewardedTotalFixedPercentage: null,
     rewardedTotalAllocationPoints: null,
     addSushiswapLiquidityLink: null,
@@ -397,7 +399,11 @@ const store = new Vuex.Store({
         state.ownedNfts = [];
       }
     },
-    loadRewardedFunds(state) {
+    loadRewardedFunds(state, ignoreWhenLoaded) {
+      if (ignoreWhenLoaded && state.rewardedFunds) {
+        // Avoid reloading only when necessary
+        return;
+      }
       if (state.tokenFactoryContract && !state.rewardedFundsLength) {
         state.tokenFactoryContract.fundsLength()
           .then(length => {
@@ -425,10 +431,99 @@ const store = new Vuex.Store({
             }
             return Promise.all(promises);
           })
-          .then(fundInfos => state.rewardedFunds = fundInfos || []);
+          .then(fundInfos => {
+            state.rewardedFunds = fundInfos || [];
+            const rewardedPools = state.rewardedFunds.filter(fund => fund.isLPToken);
+            rewardedPools.forEach(pool => {
+              pool.refresh = 0;
+              pool.loading = true;
+            });
+            state.rewardedPools = rewardedPools;
+            return this.commit('loadLPTokenAssets');
+          });
         state.tokenFactoryContract.totalAllocationPoints().then(value => state.rewardedTotalAllocationPoints = value);
         state.tokenFactoryContract.totalFixedPercentage().then(value => state.rewardedTotalFixedPercentage = value);
       }
+    },
+    loadLPTokenAssets(state) {
+      state.rewardedPools.forEach(pool => {
+        pool.contract = new ethers.Contract(
+          pool.address,
+          state.erc20ABI,
+          state.provider
+        );
+        pool.contract.symbol()
+          .then(symbol => pool.symbol = symbol);
+        this.commit('loadLPTokenAsset', pool);
+      });
+    },
+    loadLPTokenAsset(state, pool) {
+      this.commit('refreshLPUserInfo', pool);
+      this.commit('loadLPApy', pool);
+    },
+    refreshLPUserInfo(state, pool) {
+      pool.loadingUserInfo = true;
+      state.tokenFactoryContract.userLpInfos(pool.address, state.address)
+        .then(userInfo => {
+          const user = {};
+          Object.keys(userInfo).forEach(key => {
+            if (Number.isNaN(Number(key))) {
+              user[key] = userInfo[key];
+            }
+          });
+          pool.userInfo = user;
+        })
+        .finally(() => pool.loadingUserInfo = false);
+    },
+    loadLPApy(state, pool) {
+      const promises = [];
+      promises.push(
+        state.meedContract.balanceOf(pool.address)
+          .then(balance => pool.meedsBalance = balance)
+      );
+      promises.push(
+        pool.contract.balanceOf(state.tokenFactoryAddress)
+          .then(balance => pool.lpBalanceOfTokenFactory = balance)
+      );
+      promises.push(
+        pool.contract.totalSupply()
+          .then(totalSupply => pool.totalSupply = totalSupply)
+      );
+      Promise.all(promises)
+        .then(() => {
+          pool.stakedEquivalentMeedsBalanceOfPool = !pool.totalSupply.isZero()
+            && pool.meedsBalance.mul(pool.lpBalanceOfTokenFactory).mul(2).div(pool.totalSupply) || new BigNumber(0);
+          if (pool.fixedPercentage && !pool.fixedPercentage.isZero()) {
+            pool.yearlyRewardedMeeds = new BigNumber(state.rewardedMeedPerMinute.toString())
+              .multipliedBy(state.yearInMinutes)
+              .multipliedBy(pool.fixedPercentage.toString())
+              .dividedBy(100);
+          } else if (pool.allocationPoint && !pool.allocationPoint.isZero()) {
+            pool.yearlyRewardedMeeds = new BigNumber(state.rewardedMeedPerMinute.toString())
+              .multipliedBy(state.yearInMinutes)
+              .multipliedBy(pool.allocationPoint.toString())
+              .dividedBy(state.rewardedTotalAllocationPoints.toString())
+              .dividedBy(100)
+              .multipliedBy(100 - state.rewardedTotalFixedPercentage.toNumber());
+          } else {
+            pool.yearlyRewardedMeeds = new BigNumber(0);
+          }
+
+          if (state.noMeedSupplyForLPRemaining
+              || pool.stakedEquivalentMeedsBalanceOfPool.isZero()
+              || pool.yearlyRewardedMeeds.isZero()) {
+            pool.apy = 0;
+          } else {
+            pool.apy = pool.yearlyRewardedMeeds.dividedBy(pool.stakedEquivalentMeedsBalanceOfPool.toString()).multipliedBy(100);
+          }
+          pool.refresh++;
+        })
+        .finally(() => {
+          pool.loading = false;
+          // Force reloading list of pools after updated
+          const index = state.rewardedPools.findIndex(tmpPool => tmpPool === pool);
+          state.rewardedPools.splice(index, 1, pool);
+        });
     },
     loadMeedsBalances(state) {
       state.loadingMeedsBalance = true;

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
@@ -22,3 +22,10 @@
     <deeds-meeds-info />
   </div>
 </template>
+<script>
+export default {
+  created() {
+    this.$store.commit('loadRewardedFunds', true);
+  },
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
@@ -1,0 +1,143 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <deeds-token-asset-template>
+    <template #col1>
+      <deeds-contract-address
+        :address="lpAddress"
+        :label="poolName"
+        token />
+    </template>
+    <template #col2>
+      <v-skeleton-loader
+        v-if="loadingUserInfo"
+        type="chip"
+        max-height="17"
+        tile />
+      <v-tooltip v-else bottom>
+        <template #activator="{ on, attrs }">
+          <div
+            class="d-flex flex-nowrap"
+            v-bind="attrs"
+            v-on="on">
+            <deeds-number-format
+              :value="lpStaked"
+              :fractions="2" />
+            <span class="mx-1 text-no-wrap"> {{ lpSymbol }}  </span>
+          </div>
+        </template>
+        <span v-if="noMeedSupplyForLPRemaining">
+          {{ $t('maxMeedsSupplyReached') }}
+        </span>
+        <div class="d-flex flex-row">
+          <span class="mx-1 text-no-wrap"> {{ $t('apy') }} </span>
+          <deeds-number-format
+            :value="apy"
+            no-decimals>
+            %
+          </deeds-number-format>
+        </div>
+      </v-tooltip>
+    </template>
+    <template #col3>
+      <v-skeleton-loader
+        v-if="loading"
+        type="chip"
+        max-height="17"
+        tile /> 
+      <div 
+        v-else
+        class="d-flex flex-row flex-nowrap">
+        <span class="mx-1">+</span>
+        <deeds-number-format 
+          :value="weeklyRewardedMeeds" 
+          :fractions="2" />
+        <span class="mx-1 text-no-wrap">MEED / {{ $t('week') }}</span>
+      </div>
+    </template>
+    <template #col4>
+      <v-skeleton-loader
+        v-if="loadingUserInfo"
+        type="chip"
+        max-height="17"
+        tile />
+      <deeds-number-format
+        v-else
+        :value="lpStaked"
+        :fractions="2"
+        currency />
+    </template>
+  </deeds-token-asset-template>
+</template>
+<script>
+export default {
+  props: {
+    pool: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: Vuex.mapState({
+    sushiswapPairAddress: state => state.sushiswapPairAddress,
+    univ2PairAddress: state => state.univ2PairAddress,
+    isSushiswapPool() {
+      return this.sushiswapPairAddress && this.pool && this.pool.address && this.pool.address.toUpperCase() === this.sushiswapPairAddress.toUpperCase();
+    },
+    isUniswapPool() {
+      return this.univ2PairAddress && this.pool && this.pool.address && this.pool.address.toUpperCase() === this.univ2PairAddress.toUpperCase();
+    },
+    poolName() {
+      if (this.isSushiswapPool) {
+        return 'Sushiswap';
+      } else if (this.isUniswapPool) {
+        return 'Uniswap';
+      }
+      return this.lpSymbol;
+    },
+    lpAddress() {
+      return this.pool && this.pool.address;
+    },
+    lpSymbol() {
+      return this.pool && this.pool.symbol;
+    },
+    userInfo() {
+      return this.pool && this.pool.userInfo;
+    },
+    lpStaked() {
+      return this.userInfo && this.userInfo.amount || 0;
+    },
+    loadingUserInfo() {
+      return this.pool && this.pool.loadingUserInfo;
+    },
+    loading() {
+      return this.pool && this.pool.loading;
+    },
+    apy() {
+      return this.pool && this.pool.apy;
+    },
+    weeklyRewardedMeeds() {
+      return new BigNumber(this.lpStaked.toString())
+        .multipliedBy(this.apy.toString())
+        .dividedBy(100)
+        .multipliedBy(7)
+        .dividedBy(365);
+    },
+  }),
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
@@ -1,0 +1,61 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <v-row class="ps-8 pe-4 ma-0 d-flex flex-column flex-sm-row flex-grow-1">
+    <v-col
+      v-if="!isMobile || $slots.col1"
+      class="px-0 pb-0 pb-sm-3 text-no-wrap"
+      align-self="start">
+      <slot name="col1"></slot>
+    </v-col>
+    <v-divider class="d-block d-sm-none" />
+    <v-col
+      v-if="!isMobile || $slots.col2"
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
+      cols="3">
+      <slot name="col2"></slot>
+      <template v-if="isMobile && $slots.col4">
+        <small class="d-flex text-no-wrap">
+          <slot name="col4"></slot>
+        </small>
+      </template>
+    </v-col>
+    <v-col
+      v-if="!isMobile || $slots.col3"
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
+      cols="4">
+      <slot name="col3"></slot>
+    </v-col>
+    <v-col
+      v-if="!isMobile && $slots.col4"
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
+      align-self="end">
+      <slot name="col4"></slot>
+    </v-col>
+  </v-row>
+</template>
+<script>
+export default {
+  computed: {
+    isMobile() {
+      return this.$vuetify && this.$vuetify.breakpoint && this.$vuetify.breakpoint.name === 'xs';
+    },
+  },
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -21,17 +21,16 @@
     <v-list-item>
       <h4>{{ $t('tokens') }}</h4>
     </v-list-item>
-    <v-list-item class="ps-8">
-      <v-list-item-content class="align-start">
+    <deeds-token-asset-template>
+      <template #col1>
         <div>
           <deeds-contract-address
             :address="meedAddress"
             label="Meeds"
             token />
         </div>
-      </v-list-item-content>
-      <v-list-item-content />
-      <v-list-item-content class="align-end">
+      </template>
+      <template #col2>
         <v-skeleton-loader
           v-if="loadingMeedsBalance"
           type="chip"
@@ -40,8 +39,8 @@
         <template v-else>
           {{ meedsBalanceNoDecimals }} MEED
         </template>
-      </v-list-item-content>
-      <v-list-item-content class="align-end">
+      </template>
+      <template #col4>
         <v-skeleton-loader
           v-if="loadingMeedsBalance"
           type="chip"
@@ -52,20 +51,20 @@
           :value="meedsBalance"
           :fractions="2"
           currency />
-      </v-list-item-content>
-    </v-list-item>
-    <v-list-item v-if="xMeedAddress" class="ps-8">
-      <v-list-item-content class="align-start">
+      </template>
+    </deeds-token-asset-template>
+    <deeds-token-asset-template v-if="xMeedAddress">
+      <template #col1>
         <div>
           <deeds-contract-address
             :address="xMeedAddress"
             label="xMeeds"
             token />
         </div>
-      </v-list-item-content>
-      <v-list-item-content>
+      </template>
+      <template #col2>
         <v-skeleton-loader
-          v-if="apyLoading"
+          v-if="loadingXMeedsBalance"
           type="chip"
           max-height="17"
           tile />
@@ -75,48 +74,44 @@
               class="d-flex flex-nowrap"
               v-bind="attrs"
               v-on="on">
-              <deeds-number-format
-                v-if="rewardsStarted"
-                :value="apy"
-                no-decimals>
-                %
-              </deeds-number-format>
-              <v-icon
-                v-else
-                size="15px"
-                color="primary"
-                class="ms-2 mt-1">
-                mdi-alert-circle-outline
-              </v-icon>
+              {{ xMeedsBalanceNoDecimals }} xMEED
             </div>
           </template>
           <span v-if="maxMeedSupplyReached">
             {{ $t('maxMeedsSupplyReached') }}
           </span>
-          <ul v-else-if="rewardsStarted">
-            <li>
-              <deeds-number-format :value="yearlyRewardedMeeds" label="yearlyRewardedMeeds" />
-            </li>
-            <li>
-              <deeds-number-format :value="meedsTotalBalanceOfXMeeds" label="meedsTotalBalanceOfXMeeds" />
-            </li>
-          </ul>
+          <div
+            class="d-flex"
+            v-if="rewardsStarted">
+            <span class="mx-1"> {{ $t('apy') }} </span>
+            <deeds-number-format
+              :value="apy"
+              no-decimals>
+              %
+            </deeds-number-format>
+          </div>
           <div v-else>
             {{ $t('meedsRewardingDidntStarted') }}
           </div>
         </v-tooltip>
-      </v-list-item-content>
-      <v-list-item-content class="align-end">
+      </template>
+      <template #col3>
         <v-skeleton-loader
           v-if="loadingXMeedsBalance"
           type="chip"
           max-height="17"
           tile />
-        <template v-else>
-          {{ xMeedsBalanceNoDecimals }} xMEED
-        </template>
-      </v-list-item-content>
-      <v-list-item-content class="align-end">
+        <div 
+          v-else
+          class="d-flex">
+          <span class="mx-1">+</span>
+          <deeds-number-format 
+            :value="weeklyRewardedMeeds" 
+            :fractions="2" />
+          <span class="mx-1">MEED / {{ $t('week') }}</span>
+        </div>
+      </template>
+      <template #col4>
         <v-skeleton-loader
           v-if="loadingXMeedsBalance"
           type="chip"
@@ -125,16 +120,20 @@
         <deeds-number-format
           v-else
           :value="xMeedsBalanceInMeeds"
+          :fractions="2"
           currency />
-      </v-list-item-content>
-    </v-list-item>
+      </template>
+    </deeds-token-asset-template>
+    <template v-if="!poolsLoading">
+      <deeds-token-asset
+        v-for="pool in rewardedPools"
+        :key="`${pool.address}_${pool.refresh}`"
+        :pool="pool" />
+    </template>
   </v-list>
 </template>
 <script>
 export default {
-  data: () => ({
-    yearInMinutes: 365 * 24 * 60,
-  }),
   computed: Vuex.mapState({
     language: state => state.language,
     selectedFiatCurrency: state => state.selectedFiatCurrency,
@@ -145,6 +144,7 @@ export default {
     meedAddress: state => state.meedAddress,
     xMeedAddress: state => state.xMeedAddress,
     xMeedsBalance: state => state.xMeedsBalance,
+    yearInMinutes: state => state.yearInMinutes,
     rewardedMeedPerMinute: state => state.rewardedMeedPerMinute,
     rewardedTotalAllocationPoints: state => state.rewardedTotalAllocationPoints,
     rewardedTotalFixedPercentage: state => state.rewardedTotalFixedPercentage,
@@ -152,10 +152,11 @@ export default {
     xMeedsBalanceNoDecimals: state => state.xMeedsBalanceNoDecimals,
     meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,
     xMeedsTotalSupply: state => state.xMeedsTotalSupply,
-    rewardedFunds: state => state.rewardedFunds,
     meedsPendingBalanceOfXMeeds: state => state.meedsPendingBalanceOfXMeeds,
     stakingStartTime: state => state.stakingStartTime,
     maxMeedSupplyReached: state => state.maxMeedSupplyReached,
+    rewardedFunds: state => state.rewardedFunds,
+    rewardedPools: state => state.rewardedPools,
     now: state => state.now,
     xMeedsBalanceInMeeds() {
       if (this.xMeedsBalance && this.xMeedsTotalSupply && !this.xMeedsTotalSupply.isZero() && this.meedsBalanceOfXMeeds) {
@@ -194,6 +195,16 @@ export default {
     rewardsStarted() {
       return this.stakingStartTime < this.now;
     },
+    weeklyRewardedMeeds() {
+      if (this.xMeedsBalance && this.apy) {
+        return new BigNumber(this.xMeedsBalance.toString())
+          .multipliedBy(this.apy)
+          .dividedBy(100)
+          .multipliedBy(7)
+          .dividedBy(365);
+      }
+      return new BigNumber(0);
+    },
     apyLoading() {
       return this.meedsBalanceOfXMeeds == null || this.rewardedFunds == null || !this.meedsPendingBalanceOfXMeeds == null;
     },
@@ -208,9 +219,9 @@ export default {
       }
       return this.yearlyRewardedMeeds.dividedBy(this.meedsTotalBalanceOfXMeeds.toString()).multipliedBy(100);
     },
+    poolsLoading() {
+      return !this.rewardedPools || this.rewardedPools.filter(pool => pool.loading).length > 0;
+    },
   }),
-  created() {
-    this.$store.commit('loadRewardedFunds');
-  },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -17,7 +17,9 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-list dense>
+  <v-list 
+    v-if="rewardedPools"
+    dense >
     <v-list-item>
       <h4>{{ $t('tokens') }}</h4>
     </v-list-item>
@@ -124,12 +126,10 @@
           currency />
       </template>
     </deeds-token-asset-template>
-    <template v-if="!poolsLoading">
-      <deeds-token-asset
-        v-for="pool in rewardedPools"
-        :key="`${pool.address}_${pool.refresh}`"
-        :pool="pool" />
-    </template>
+    <deeds-token-asset
+      v-for="pool in rewardedPools"
+      :key="`${pool.address}_${pool.refresh}`"
+      :pool="pool" />
   </v-list>
 </template>
 <script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/CurrenciesChart.vue
@@ -42,13 +42,13 @@ export default {
         Object.keys(this.metrics.lockedBalances).forEach((address) => {
           let name;
           const lockedBalance = this.metrics.lockedBalances[address];
-          if (address.toLowerCase() === this.comethPairAddress.toLowerCase()) {
+          if (address.toLowerCase() === this.comethPairAddress?.toLowerCase()) {
             name = this.$t('comethPool');
-          } else if (address.toLowerCase() === this.xMeedAddress.toLowerCase()) {
+          } else if (address.toLowerCase() === this.xMeedAddress?.toLowerCase()) {
             name = this.$t('xMeedsStaked');
-          } else if (address.toLowerCase() === this.sushiswapPairAddress.toLowerCase()) {
+          } else if (address.toLowerCase() === this.sushiswapPairAddress?.toLowerCase()) {
             name = this.$t('sushiSwapPool');
-          } else if (address.toLowerCase() === this.vestingAddress.toLowerCase()) {
+          } else if (address.toLowerCase() === this.vestingAddress?.toLowerCase()) {
             name = this.$t('vestedMeeds');
           } else {
             name = this.$t('others');

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
@@ -21,6 +21,8 @@ import PriceChart from './components/charts/PriceChart.vue';
 import TradeMeeds from './components/TradeMeeds.vue';
 import Assets from './components/Assets.vue';
 import TokenAssets from './components/assets/TokenAssets.vue';
+import TokenAssetTemplate from './components/assets/TokenAssetTemplate.vue';
+import TokenAsset from './components/assets/TokenAsset.vue';
 import DeedAssets from './components/assets/DeedAssets.vue';
 import MeedsInfo from './components/MeedsInfo.vue';
 import CurrenciesChart from './components/charts/CurrenciesChart.vue';
@@ -31,6 +33,8 @@ const components = {
   'deeds-trade-meeds': TradeMeeds,
   'deeds-assets': Assets,
   'deeds-token-assets': TokenAssets,
+  'deeds-token-asset': TokenAsset,
+  'deeds-token-asset-template': TokenAssetTemplate,
   'deeds-deed-assets': DeedAssets,
   'deeds-meeds-info': MeedsInfo,
   'deeds-currencies-chart': CurrenciesChart,

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/Stake.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/Stake.vue
@@ -30,7 +30,7 @@
 <script>
 export default {
   created() {
-    this.$store.commit('loadRewardedFunds');
+    this.$store.commit('loadRewardedFunds', true);
   },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeMeeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeMeeds.vue
@@ -227,7 +227,6 @@
 export default {
   data: () => ({
     stake: true,
-    yearInMinutes: 365 * 24 * 60,
   }),
   computed: Vuex.mapState({
     meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,
@@ -246,6 +245,7 @@ export default {
     stakingStartTime: state => state.stakingStartTime,
     maxMeedSupplyReached: state => state.maxMeedSupplyReached,
     now: state => state.now,
+    yearInMinutes: state => state.yearInMinutes,
     xMeedRewardInfo() {
       return this.rewardedFunds && this.xMeedAddress && this.rewardedFunds.find(fund => fund.address.toUpperCase() === this.xMeedAddress.toUpperCase());
     },


### PR DESCRIPTION
Prior to this change, in the first section "Your assets", the tokens were displayed in a table with the value of the APY, the balance token and the amount in USD/EUR.
This change will present, the token with the address of the contract, the balance of this token that the user has (tooltiped with the APY), the gain value from staked tokens per week and the amount of the balance that the user had.