### PR TITLE
feat: Investors App Add a description when there is no tokens to display - MEED-504 - meeds-io/meeds#

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -248,7 +248,15 @@ export default {
   }),
   watch: {
     poolsLoading() {
-      if (this.rewardedPools) {
+      this.updateTokenNumber();
+    },
+  },
+  mounted() {
+    this.updateTokenNumber();
+  },
+  methods: {
+    updateTokenNumber() {
+      if (this.rewardedPools && !this.poolsLoading) {
         this.rewardedPools.filter(pool => {
           if (!pool.userInfo?.amount.isZero()) {
             this.tokenCount ++;
@@ -261,7 +269,7 @@ export default {
       if (this.xMeedsBalance && !this.xMeedsBalance.isZero()) {
         this.tokenCount ++;
       }
-    },
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, when switching from one tab to another, the overview tab was not displayed correctly (for a user with tokens).
This change corrects this problem.