### PR TITLE
feat: Investors App Add a description when there is no tokens to display - MEED-504

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -258,7 +258,7 @@ export default {
     updateTokenNumber() {
       if (this.rewardedPools && !this.poolsLoading) {
         this.rewardedPools.filter(pool => {
-          if (!pool.userInfo?.amount.isZero()) {
+          if (!pool?.loadingUserInfo && pool?.userInfo?.amount && !pool.userInfo.amount.isZero()) {
             this.tokenCount ++;
           }
         });

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -258,7 +258,7 @@ export default {
     updateTokenNumber() {
       if (this.rewardedPools && !this.poolsLoading) {
         this.rewardedPools.filter(pool => {
-          if (!pool?.loadingUserInfo && pool?.userInfo?.amount && !pool.userInfo.amount.isZero()) {
+          if (!pool?.loadingUserInfo && pool?.userInfo?.amount && !pool?.userInfo?.amount?.isZero()) {
             this.tokenCount ++;
           }
         });


### PR DESCRIPTION
Before this change, a blank space was displayed after the loading effect (in case the user had no tokens).
This change fixes this problem by displaying the block description when there are no tokens.