### PR TITLE
fix: Investors App Update the topbar display when using mobile - MEED-597

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Topbar.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Topbar.vue
@@ -45,7 +45,7 @@
     <div class="ms-4">
       <deeds-topbar-fiat-currency-selector v-if="address" />
     </div>
-    <div class="ms-4 d-none d-sm-inline-block">
+    <div class="ms-4">
       <deeds-topbar-language-selector />
     </div>
   </v-toolbar>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/FiatCurrencySelector.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/FiatCurrencySelector.vue
@@ -44,16 +44,20 @@
 export default {
   data: () => ({
     fiatCurrencies: ['usd', 'eur', 'eth'],
+    symbolFiatCurrencies: ['$', '€', 'Ξ']
   }),
   computed: Vuex.mapState({
     selectedFiatCurrency: state => state.selectedFiatCurrency,
+    isMobile() {
+      return this.$vuetify?.breakpoint?.smAndDown;
+    },
     selectedFiatCurrencyLabel() {
-      return this.$t(`fiat.currency.${this.selectedFiatCurrency}`);
+      return this.isMobile ? this.symbolFiatCurrencies[this.fiatCurrencies.indexOf(this.selectedFiatCurrency)] : this.$t(`fiat.currency.${this.selectedFiatCurrency}`);
     },
     fiatCurrencyOptions() {
-      return this.fiatCurrencies.map(currency => ({
+      return this.fiatCurrencies.map((currency, index) => ({
         value: currency,
-        label: this.$t(`fiat.currency.${currency}`),
+        label: this.isMobile ? this.symbolFiatCurrencies[index] : this.$t(`fiat.currency.${currency}`),
       }));
     },
   }),

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/LanguageSelector.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/LanguageSelector.vue
@@ -47,13 +47,16 @@ export default {
   }),
   computed: Vuex.mapState({
     selectedLanguage: state => state.language,
+    isMobile() {
+      return this.$vuetify?.breakpoint?.smAndDown;
+    },
     selectedLanguageLabel() {
-      return this.$t(`language.${this.selectedLanguage}`);
+      return this.isMobile ? this.selectedLanguage : this.$t(`language.${this.selectedLanguage}`);
     },
     languageOptions() {
       return this.languages.map(language => ({
         value: language,
-        label: this.$t(`language.${language}`),
+        label: this.isMobile ? language.toUpperCase() : this.$t(`language.${language}`),
       }));
     },
   }),


### PR DESCRIPTION
Prior to this change, the top bar contains the logo and name of the dapp, as well as the currency dropdown.
This change will update the fiat currency selector with symbols ($, € and Ξ) and add the language dropdown with abbreviations (FR and EN).