### PR TITLE
fix: Investors App Update the yield value from SLP to MEED - MEED-587

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAsset.vue
@@ -120,7 +120,7 @@ export default {
     weeklyRewardedInSLP() {
       if (this.lpStaked && this.apy) {
         return new BigNumber(this.lpStaked.toString())
-          .multipliedBy(this.apy.toString())
+          .multipliedBy(Math.trunc(this.apy))
           .dividedBy(100)
           .multipliedBy(7)
           .dividedBy(365);


### PR DESCRIPTION
Prior to this change, the calculated yield value did not correspond to the displayed value (because of the APY value)
This change allows the yield to be calculated with the APY without decimals to get the exact result.
