### PR TITLE
fix: Investors App Update the yield value from XMeed to Meed - MEED-588

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -212,7 +212,7 @@ export default {
     weeklyRewardedInXMeed() {
       if (this.xMeedsBalance && this.apy) {
         return new BigNumber(this.xMeedsBalance.toString())
-          .multipliedBy(this.apy)
+          .multipliedBy(Math.trunc(this.apy))
           .dividedBy(100)
           .multipliedBy(7)
           .dividedBy(365);


### PR DESCRIPTION
Prior to this change, the calculated yield value in Meed did not correspond to the displayed value (because of the APY value)
This change allows the yield to be calculated with the APY without decimals to get the exact result.