### PR TITLE
fix: Investors App Update the yield value from XMeed to Meed - MEED-588

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssets.vue
@@ -212,7 +212,7 @@ export default {
     weeklyRewardedInXMeed() {
       if (this.xMeedsBalance && this.apy) {
         return new BigNumber(this.xMeedsBalance.toString())
-          .multipliedBy(Math.trunc(this.apy))
+          .multipliedBy(this.$ethUtils.toFixedDisplay(this.apy, 0, this.language))
           .dividedBy(100)
           .multipliedBy(7)
           .dividedBy(365);


### PR DESCRIPTION
Prior to this change, the APY value used was uncorrect, the value needed to be rounded and then used without decimals.
This change will solve this problem.