### PR TITLE
fix: Fix displaying Meed Metrics in EURO and ETH Currencies - MEED-630

### DIFF
--- a/deeds-dapp-service/pom.xml
+++ b/deeds-dapp-service/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>deeds-dapp-service</artifactId>
   <name>Meeds:: Deeds Dapp - Services</name>
   <properties>
-    <exo.test.coverage.ratio>0.44</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.48</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/DeedMetadataController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/DeedMetadataController.java
@@ -19,8 +19,6 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
@@ -37,7 +35,7 @@ public class DeedMetadataController {
   private DeedMetadataService deedMetadataService;
 
   @GetMapping
-  public ResponseEntity<DeedMetadataPresentation> getContractMetadata(HttpServletRequest request) {
+  public ResponseEntity<DeedMetadataPresentation> getContractMetadata() {
     DeedMetadata deedMetadata = deedMetadataService.getContractMetadata();
     return getDeedMetadataResponse(deedMetadata);
   }
@@ -45,8 +43,7 @@ public class DeedMetadataController {
   @GetMapping("/{nftId}")
   public ResponseEntity<DeedMetadataPresentation> getNftMetadata(
                                                                  @PathVariable(name = "nftId")
-                                                                 Long nftId,
-                                                                 HttpServletRequest request) {
+                                                                 Long nftId) {
     DeedMetadata deedMetadata = deedMetadataService.getDeedMetadata(nftId);
     return getDeedMetadataResponse(deedMetadata);
   }
@@ -56,8 +53,7 @@ public class DeedMetadataController {
                                                                  @PathVariable(name = "cityIndex")
                                                                  short cityIndex,
                                                                  @PathVariable(name = "cardType")
-                                                                 short cardType,
-                                                                 HttpServletRequest request) {
+                                                                 short cardType) {
     DeedMetadata deedMetadata = deedMetadataService.getDeedMetadataOfCard(cityIndex, cardType);
     return getDeedMetadataResponse(deedMetadata);
   }

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/rest/MeedTokenMetricController.java
@@ -23,8 +23,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.meeds.deeds.constant.Currency;
 import io.meeds.deeds.model.MeedTokenMetric;
 import io.meeds.deeds.service.MeedTokenMetricService;
 
@@ -36,8 +38,10 @@ public class MeedTokenMetricController {
   private MeedTokenMetricService meedTokenMetricService;
 
   @GetMapping(value = "/", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<MeedTokenMetric> getMetrics() {
-    return ResponseEntity.ok(meedTokenMetricService.getLastMetric());
+  public ResponseEntity<MeedTokenMetric> getMetrics(
+                                                    @RequestParam(name = "currency", required = false)
+                                                    Currency currency) {
+    return ResponseEntity.ok(meedTokenMetricService.getLastMetric(currency));
   }
 
   @GetMapping("/circ")
@@ -49,16 +53,20 @@ public class MeedTokenMetricController {
   }
 
   @GetMapping("/mcap")
-  public ResponseEntity<BigDecimal> getMarketCapitalization() {
-    BigDecimal marketCapitalization = meedTokenMetricService.getMarketCapitalization();
+  public ResponseEntity<BigDecimal> getMarketCapitalization(
+                                                            @RequestParam(name = "currency", required = false)
+                                                            Currency currency) {
+    BigDecimal marketCapitalization = meedTokenMetricService.getMarketCapitalization(currency);
     return ResponseEntity.ok()
                          .cacheControl(CacheControl.noCache().cachePublic())
                          .body(marketCapitalization);
   }
 
   @GetMapping("/tvl")
-  public ResponseEntity<BigDecimal> getTotalLockedValue() {
-    BigDecimal totalValueLocked = meedTokenMetricService.getTotalValueLocked();
+  public ResponseEntity<BigDecimal> getTotalLockedValue(
+                                                        @RequestParam(name = "currency", required = false)
+                                                        Currency currency) {
+    BigDecimal totalValueLocked = meedTokenMetricService.getTotalValueLocked(currency);
     return ResponseEntity.ok()
                          .cacheControl(CacheControl.noCache().cachePublic())
                          .body(totalValueLocked);

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/rest/MeedTokenMetricControllerTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/rest/MeedTokenMetricControllerTest.java
@@ -67,7 +67,7 @@ class MeedTokenMetricControllerTest {
                                                  new BigDecimal("6"),
                                                  new BigDecimal("7"));
 
-    when(meedTokenMetricService.getLastMetric()).thenReturn(result);
+    when(meedTokenMetricService.getLastMetric(null)).thenReturn(result);
 
     ResultActions response = mockMvc.perform(get("/api/token/meed/"));
     response.andExpect(status().isOk())
@@ -98,7 +98,7 @@ class MeedTokenMetricControllerTest {
 
     BigDecimal marketCapitalization = new BigDecimal("5");
 
-    when(meedTokenMetricService.getMarketCapitalization()).thenReturn(marketCapitalization);
+    when(meedTokenMetricService.getMarketCapitalization(null)).thenReturn(marketCapitalization);
 
     ResultActions response = mockMvc.perform(get("/api/token/meed/mcap"));
     response.andExpect(status().isOk())
@@ -110,7 +110,7 @@ class MeedTokenMetricControllerTest {
 
     BigDecimal totalValuelocked = new BigDecimal("4");
 
-    when(meedTokenMetricService.getTotalValueLocked()).thenReturn(totalValuelocked);
+    when(meedTokenMetricService.getTotalValueLocked(null)).thenReturn(totalValuelocked);
 
     ResultActions response = mockMvc.perform(get("/api/token/meed/tvl"));
     response.andExpect(status().isOk())

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/js/tokenMetricService.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/js/tokenMetricService.js
@@ -17,8 +17,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export function getMetrics() {
-  return fetch(`/${window.parentAppLocation}/api/token/meed/`, {
+export function getMetrics(currency) {
+  return fetch(`/${window.parentAppLocation}/api/token/meed/?currency=${currency?.toUpperCase() || 'USD'}`, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/MeedsInfo.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/MeedsInfo.vue
@@ -97,13 +97,21 @@ export default {
       }
     },
   }),
+  watch: {
+    selectedFiatCurrency() {
+      this.refreshMetrics();
+    },
+  },
   created() {
-    this.$tokenMetricService.getMetrics()
-      .then(metrics => {
-        this.metrics = metrics;
-      });
+    this.refreshMetrics();
   },
   methods: {
+    refreshMetrics() {
+      this.$tokenMetricService.getMetrics(this.selectedFiatCurrency)
+        .then(metrics => {
+          this.metrics = metrics;
+        });
+    },
     currencyFormat(currencyValue) {
       const value = currencyValue && currencyValue.value || currencyValue;
       if (this.selectedFiatCurrency === 'eth') {


### PR DESCRIPTION
Prior to this change, the Meed Token Metrics was displayed in USD currency only and not converted to other currencies. This change allows to retrieve Token Metrics in EURO and ETH currencies in addition to USD Metric.