### PR TITLE
feat: Enhance Overview Token Assets Links - MEED-575

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/ContractAddress.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/ContractAddress.vue
@@ -1,3 +1,21 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
 <template>
   <v-menu
     v-model="menu"

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/Drawer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/Drawer.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/NumberFormat.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/NumberFormat.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/TabLink.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/common/components/TabLink.vue
@@ -17,16 +17,24 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column">
-    <deeds-add-liquidity />
-    <deeds-rent-liquidity />
-    <deeds-liquidity-pools />
-  </div>
+  <v-btn
+    color="tertiary"
+    text
+    @click="$root.$emit('switch-page', tabLink)">
+    <span class="text-none font-weight-bold">{{ label }}</span>
+  </v-btn>
 </template>
 <script>
 export default {
-  created() {
-    this.$store.commit('loadRewardedFunds', true);
+  props: {
+    label: {
+      type: String,
+      default: null,
+    },
+    tabLink: {
+      type: String,
+      default: null,
+    },
   },
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/common/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/common/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,6 +19,7 @@
 import Drawer from './components/Drawer.vue';
 import NumberFormat from './components/NumberFormat.vue';
 import ContractAddress from './components/ContractAddress.vue';
+import TabLink from './components/TabLink.vue';
 import MetamaskButton from './components/MetamaskButton.vue';
 
 const components = {
@@ -26,6 +27,7 @@ const components = {
   'deeds-number-format': NumberFormat,
   'deeds-contract-address': ContractAddress,
   'deeds-metamask-button': MetamaskButton,
+  'deeds-tab-link': TabLink,
 };
 
 for (const key in components) {

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/Deeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/Deeds.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsEarnedPoints.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsEarnedPoints.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -48,7 +48,7 @@
                   tile />
               </template>
               <template v-else>
-                <deeds-number-format :value="xMeedsTotalSupply">
+                <deeds-number-format :value="xMeedsTotalSupply" :fractions="2">
                   <deeds-contract-address
                     :address="xMeedAddress"
                     :button-top="-2"
@@ -87,12 +87,13 @@
                 max-height="17"
                 tile />
               <template v-else>
-                {{ xMeedsBalanceNoDecimals }}
-                <deeds-contract-address
-                  :address="xMeedAddress"
-                  :button-top="-2"
-                  label="xMEED"
-                  token />
+                <deeds-number-format :value="xMeedsBalance" :fractions="2">
+                  <deeds-contract-address
+                    :address="xMeedAddress"
+                    :button-top="-2"
+                    label="xMEED"
+                    token />
+                </deeds-number-format>
               </template>
             </v-list-item-subtitle>
           </v-list-item-content>
@@ -134,7 +135,6 @@ export default {
     meedsBalance: state => state.meedsBalance,
     xMeedsBalance: state => state.xMeedsBalance,
     pointsBalance: state => state.pointsBalance,
-    xMeedsBalanceNoDecimals: state => state.xMeedsBalanceNoDecimals,
     maxMeedSupplyReached: state => state.maxMeedSupplyReached,
     meedsPendingBalanceOfXMeeds: state => state.meedsPendingBalanceOfXMeeds,
     meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsNftIntroduction.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsNftIntroduction.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsOwned.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsOwned.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsPointsSimulator.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsPointsSimulator.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -71,9 +71,7 @@ export default {
     language: state => state.language,
     tokenLoading: state => state.tokenLoading,
     xMeedsBalance: state => state.xMeedsBalance,
-    xMeedsBalanceNoDecimals() {
-      return this.xMeedsBalance && this.$ethUtils.fromDecimals(this.xMeedsBalance, 18) || 0;
-    },
+    xMeedsBalanceNoDecimals: state => state.xMeedsBalanceNoDecimals,
     dailyPoints() {
       if (!this.xMeedAmount) {
         return 0;

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsRedeem.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsRedeem.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsRedeemCard.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsRedeemCard.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsTimer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsTimer.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsTrade.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsTrade.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/drawers/DeedMoveInDrawer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/drawers/DeedMoveInDrawer.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/drawers/DeedMoveOutDrawer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/drawers/DeedMoveOutDrawer.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/AddLiquidity.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/AddLiquidity.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPool.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPool.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -117,7 +117,7 @@
                     tile />
                 </template>
                 <template v-else>
-                  <deeds-number-format :value="lpBalanceOfTokenFactory">
+                  <deeds-number-format :value="lpBalanceOfTokenFactory" :fractions="2">
                     <deeds-contract-address
                       :address="lpAddress"
                       :label="lpSymbol"

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPools.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/LiquidityPools.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/RentLiquidity.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/RentLiquidity.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/drawer/StakeLiquidityDrawer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/drawer/StakeLiquidityDrawer.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/drawer/StakeLiquiditySteps.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/drawer/StakeLiquiditySteps.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/drawer/StakeLiquidityUnstake.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/components/drawer/StakeLiquidityUnstake.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/farming/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/farming/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/js/ethUtils.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/js/ethUtils.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/js/exchange.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/js/exchange.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/js/tokenUtils.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/js/tokenUtils.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Navbar.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Navbar.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Notifications.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Notifications.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Page.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Page.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Site.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Site.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Topbar.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/Topbar.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/AddressSelector.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/AddressSelector.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/FiatCurrencySelector.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/FiatCurrencySelector.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/LanguageSelector.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/components/topbar/LanguageSelector.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/layout/routes.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/layout/routes.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -220,7 +220,6 @@ const store = new Vuex.Store({
     xMeedsBalance: null,
     xMeedsBalanceNoDecimals: null,
     pointsBalance: null,
-    pointsBalanceNoDecimals: null,
     ownedNfts: null,
     selectedFiatCurrency,
     noCityLeft: false,
@@ -311,9 +310,8 @@ const store = new Vuex.Store({
       state.language = language;
       i18n.locale = language.indexOf('fr') === 0 ? 'fr' : 'en';
       localStorage.setItem('deeds-selectedLanguage', state.language);
-      state.meedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.meedsBalance, 3, state.language);
-      state.xMeedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.xMeedsBalance, 3, state.language);
-      state.pointsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.pointsBalance, 3, state.language);
+      state.meedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.meedsBalance, 2, state.language);
+      state.xMeedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.xMeedsBalance, 2, state.language);
     },
     setEtherBalance(state, etherBalance) {
       state.etherBalance = etherBalance;
@@ -323,14 +321,14 @@ const store = new Vuex.Store({
     },
     setMeedsBalance(state, meedsBalance) {
       state.meedsBalance = meedsBalance;
-      state.meedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.meedsBalance, 3, state.language);
+      state.meedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.meedsBalance, 2, state.language);
     },
     setMeedsRouteAllowance(state, meedsRouteAllowance) {
       state.meedsRouteAllowance = meedsRouteAllowance;
     },
     setXMeedsBalance(state, xMeedsBalance) {
       state.xMeedsBalance = xMeedsBalance;
-      state.xMeedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.xMeedsBalance, 3, state.language);
+      state.xMeedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.xMeedsBalance, 2, state.language);
     },
     loadPointsPeriodically() {
       window.setInterval(() => this.commit('loadPointsBalance'), 20000);
@@ -340,11 +338,9 @@ const store = new Vuex.Store({
         tokenUtils.getPointsBalance(state.xMeedContract, state.address)
           .then(balance => {
             state.pointsBalance = balance;
-            state.pointsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.pointsBalance, 3, state.language);
           });
       } else {
         state.pointsBalance = 0;
-        state.pointsBalanceNoDecimals = 0;
       }
     },
     loadCurrentCity(state, reloadOnNotMintable) {

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Assets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Assets.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/MeedsInfo.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/MeedsInfo.vue
@@ -34,7 +34,12 @@
           <h4>{{ $t('circulatingSupply') }}</h4>
         </v-list-item-content>
         <v-list-item-content class="align-end">
-          {{ circulatingSupply }} MEED
+          <deeds-number-format
+            :value="circulatingSupply"
+            :fractions="2"
+            no-decimals>
+            MEED
+          </deeds-number-format>
         </v-list-item-content>
       </v-list-item>
       <v-list-item>
@@ -80,7 +85,7 @@ export default {
       }
     },
     circulatingSupply() {
-      return this.$ethUtils.toFixedDisplay(this.metrics?.circulatingSupply, 3, this.language);
+      return this.metrics?.circulatingSupply;
     },
     marketCap() {
       if (this.metrics) {

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/MeedsInfo.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/MeedsInfo.vue
@@ -22,41 +22,55 @@
       {{ $t('meedToken') }}
       <v-divider class="my-auto ms-4" />
     </h3>
-    <v-list>
-      <v-list-item>
-        <v-list-item-content class="align-start">
-          <h4>{{ $t('marketCap') }}</h4>
-        </v-list-item-content>
-        <v-list-item-content class="align-end">
-          {{ marketCap }}
-        </v-list-item-content>
-        <v-list-item-content class="align-end">
-          <h4>{{ $t('circulatingSupply') }}</h4>
-        </v-list-item-content>
-        <v-list-item-content class="align-end">
-          <deeds-number-format
-            :value="circulatingSupply"
-            :fractions="2"
-            no-decimals>
-            MEED
-          </deeds-number-format>
-        </v-list-item-content>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-content class="align-start">
-          <h4>{{ $t('meedPrice') }}</h4>
-        </v-list-item-content>
-        <v-list-item-content class="align-end">
-          {{ meedsPriceToDisplay }}
-        </v-list-item-content>
-        <v-list-item-content class="align-end">
-          <h4>TVL</h4>
-        </v-list-item-content>
-        <v-list-item-content class="align-end">
-          {{ totalValuelocked }}
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
+    <v-row>
+      <v-col cols="12" sm="6">
+        <v-list-item>
+          <v-list-item-content class="align-start">
+            <h4>{{ $t('marketCap') }}</h4>
+          </v-list-item-content>
+          <v-list-item-content class="align-end">
+            {{ marketCap }}
+          </v-list-item-content>
+        </v-list-item>
+      </v-col>
+      <v-col cols="12" sm="6">
+        <v-list-item>
+          <v-list-item-content class="align-end">
+            <h4>{{ $t('circulatingSupply') }}</h4>
+          </v-list-item-content>
+          <v-list-item-content class="align-end">
+            <deeds-number-format
+              :value="circulatingSupply"
+              :fractions="2"
+              no-decimals>
+              MEED
+            </deeds-number-format>
+          </v-list-item-content>
+        </v-list-item>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12" sm="6">
+        <v-list-item>
+          <v-list-item-content class="align-start">
+            <h4>{{ $t('meedPrice') }}</h4>
+          </v-list-item-content>
+          <v-list-item-content class="align-end">
+            {{ meedsPriceToDisplay }}
+          </v-list-item-content>
+        </v-list-item>
+      </v-col>
+      <v-col cols="12" sm="6">
+        <v-list-item>
+          <v-list-item-content class="align-end">
+            <h4>TVL</h4>
+          </v-list-item-content>
+          <v-list-item-content class="align-end">
+            {{ totalValuelocked }}
+          </v-list-item-content>
+        </v-list-item>
+      </v-col>
+    </v-row>
     <div class="d-flex flex-column flex-sm-row">
       <deeds-price-chart class="mb-4 mb-sm-8" />
       <deeds-currencies-chart 

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/Overview.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/TradeMeeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/TradeMeeds.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/DeedAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/DeedAssets.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/EmptyTokenAssets.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/EmptyTokenAssets.vue
@@ -17,43 +17,41 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-container class="mt-2">
-    <v-row class="mx-auto" no-gutters>
-      <v-col
-        v-for="card in cards"
-        :key="card.name">
-        <deeds-redeem-card
-          :card="card"
-          :loading="loadingCityDetails" />
-      </v-col>
-    </v-row>
-  </v-container>
+  <v-row class="ms-4 d-flex flex-row">
+    <v-col class="pa-0" align-self="start">
+      <v-img 
+        height="100px"
+        width="140px"
+        :src="`/${parentLocation}/static/images/meeds.png`"
+        contain
+        eager />
+    </v-col>
+    <v-col cols="9">
+      <v-card flat>
+        <v-card-text class="py-0">
+          {{ $t('noTokensDescription') }}
+        </v-card-text>
+        <v-card-text class="d-flex">
+          <div class="pe-1">
+            {{ $t('see') }}
+          </div>
+          <a
+            class="text-decoration-underline"
+            @click="$root.$emit('switch-page', 'stake')">
+            {{ $t('there') }}
+          </a>
+          <div class="ps-1">
+            {{ $t('moreInformation') }}
+          </div>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
 </template>
 <script>
 export default {
-  data: () => ({
-    cards: [
-      {
-        'name': 'Common',
-        'cardType': 0,
-        'amount': new BigNumber('0x01b1ae4d6e2ef5000000')
-      },
-      {
-        'name': 'Uncommon',
-        'cardType': '1',
-        'amount': new BigNumber('0x06c6b935b8bbd4000000')
-      },
-      {
-        'name': 'Rare',
-        'cardType': '2',
-        'amount': new BigNumber('0x0a968163f0a57b400000')
-      },
-      {
-        'name': 'Legendary',
-        'cardType': '3',
-        'amount': new BigNumber('0x152d02c7e14af6800000')
-      }
-    ],
+  computed: Vuex.mapState({
+    parentLocation: state => state.parentLocation,
   }),
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/LiquidityPoolAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/LiquidityPoolAsset.vue
@@ -19,10 +19,10 @@
 <template>
   <deeds-token-asset-template v-if="hasStakedToken">
     <template #col1>
-      <deeds-contract-address
-        :address="lpAddress"
+      <deeds-tab-link
         :label="poolName"
-        token />
+        tab-link="farm"
+        class="ms-n4 mb-n2 mt-n1" />
     </template>
     <template #col2>
       <div

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/MeedAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/MeedAsset.vue
@@ -17,16 +17,36 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div class="d-flex flex-column">
-    <deeds-add-liquidity />
-    <deeds-rent-liquidity />
-    <deeds-liquidity-pools />
-  </div>
+  <deeds-token-asset-template>
+    <template #col1>
+      <deeds-tab-link
+        label="Meeds"
+        tab-link="stake"
+        class="ms-n4 mb-n2 mt-n1" />
+    </template>
+    <template #col2>
+      <deeds-number-format
+        :value="meedsBalance"
+        :fractions="2">
+        MEED
+      </deeds-number-format>
+    </template>
+    <template #col3>
+      <div class="ms-n15 d-flex justify-center">-</div>
+    </template>
+    <template #col4>
+      <deeds-number-format
+        :value="meedsBalance"
+        :fractions="2"
+        currency />
+    </template>
+  </deeds-token-asset-template>
 </template>
 <script>
 export default {
-  created() {
-    this.$store.commit('loadRewardedFunds', true);
-  },
+  computed: Vuex.mapState({
+    meedAddress: state => state.meedAddress,
+    meedsBalance: state => state.meedsBalance,
+  }),
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/MeedAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/MeedAsset.vue
@@ -31,7 +31,7 @@
         MEED
       </deeds-number-format>
     </template>
-    <template #col3>
+    <template v-if="!isMobile" #col3>
       <div class="ms-n15 d-flex justify-center">-</div>
     </template>
     <template #col4>
@@ -47,6 +47,7 @@ export default {
   computed: Vuex.mapState({
     meedAddress: state => state.meedAddress,
     meedsBalance: state => state.meedsBalance,
+    isMobile: state => state.isMobile,
   }),
 };
 </script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
@@ -20,7 +20,7 @@
   <v-row class="ps-8 pe-4 ma-0 d-flex flex-column flex-sm-row flex-grow-1">
     <v-col
       v-if="!isMobile || $slots.col1"
-      class="px-0 pb-0 pb-sm-3 text-no-wrap"
+      class="pa-0 py-sm-3 text-no-wrap"
       align-self="start">
       <slot name="col1"></slot>
     </v-col>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/TokenAssetTemplate.vue
@@ -44,8 +44,7 @@
     </v-col>
     <v-col
       v-if="!isMobile && $slots.col4"
-      class="pe-0 ps-4 ps-sm-0 text-no-wrap"
-      align-self="end">
+      class="pe-0 ps-4 ps-sm-0 text-no-wrap">
       <slot name="col4"></slot>
     </v-col>
   </v-row>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/XMeedAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/XMeedAsset.vue
@@ -1,0 +1,147 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+ 
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<template>
+  <deeds-token-asset-template>
+    <template #col1>
+      <deeds-tab-link
+        label="xMeeds"
+        tab-link="stake"
+        class="ms-n4 mb-n2 mt-n1" />
+    </template>
+    <template #col2>
+      <deeds-number-format
+        :value="xMeedsBalance"
+        :fractions="2">
+        xMEED
+      </deeds-number-format>
+    </template>
+    <template #col3>
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <div
+            class="d-flex flex-nowrap"
+            v-bind="attrs"
+            v-on="on">
+            <span class="mx-1">+</span>
+            <deeds-number-format 
+              :value="weeklyRewardedInMeed" 
+              :fractions="2" />
+            <span class="mx-1">MEED / {{ $t('week') }}</span>
+          </div>
+        </template>
+        <span v-if="maxMeedSupplyReached">
+          {{ $t('maxMeedsSupplyReached') }}
+        </span>
+        <div class="d-flex">
+          <span class="mx-1"> {{ $t('apy') }} </span>
+          <deeds-number-format
+            :value="apy"
+            no-decimals>
+            %
+          </deeds-number-format>
+        </div>
+      </v-tooltip>
+    </template>
+    <template #col4>
+      <deeds-number-format
+        :value="xMeedsBalanceInMeeds"
+        :fractions="2"
+        currency />
+    </template>
+  </deeds-token-asset-template>
+</template>
+<script>
+export default {
+  computed: Vuex.mapState({
+    xMeedAddress: state => state.xMeedAddress,
+    xMeedsBalance: state => state.xMeedsBalance,
+    xMeedsTotalSupply: state => state.xMeedsTotalSupply,
+    meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,
+    rewardedFunds: state => state.rewardedFunds,
+    yearInMinutes: state => state.yearInMinutes,
+    rewardedMeedPerMinute: state => state.rewardedMeedPerMinute,
+    rewardedTotalAllocationPoints: state => state.rewardedTotalAllocationPoints,
+    rewardedTotalFixedPercentage: state => state.rewardedTotalFixedPercentage,
+    meedsPendingBalanceOfXMeeds: state => state.meedsPendingBalanceOfXMeeds,
+    maxMeedSupplyReached: state => state.maxMeedSupplyReached,
+    xMeedRewardInfo() {
+      return this.rewardedFunds && this.xMeedAddress && this.rewardedFunds.find(fund => fund.address.toUpperCase() === this.xMeedAddress.toUpperCase());
+    },
+    xMeedsBalanceInMeeds() {
+      if (this.xMeedsBalance && this.xMeedsTotalSupply && !this.xMeedsTotalSupply.isZero() && this.meedsBalanceOfXMeeds) {
+        return this.xMeedsBalance.mul(this.meedsBalanceOfXMeeds).div(this.xMeedsTotalSupply);
+      } else {
+        return 0;
+      }
+    },
+    weeklyRewardedInXMeed() {
+      if (this.xMeedsBalance && this.apy) {
+        return new BigNumber(this.xMeedsBalance.toString())
+          .multipliedBy(this.apy)
+          .dividedBy(100)
+          .multipliedBy(7)
+          .dividedBy(365);
+      }
+      return new BigNumber(0);
+    },
+    weeklyRewardedInMeed() {
+      if (this.weeklyRewardedInXMeed && this.xMeedsTotalSupply && this.meedsBalanceOfXMeeds) {
+        return this.weeklyRewardedInXMeed
+          .dividedBy(this.xMeedsTotalSupply.toString())
+          .multipliedBy(this.meedsBalanceOfXMeeds.toString());
+      }
+      return 0;
+    },
+    meedsTotalBalanceOfXMeeds() {
+      return this.meedsBalanceOfXMeeds
+        && this.meedsPendingBalanceOfXMeeds
+        && this.meedsBalanceOfXMeeds.add(this.meedsPendingBalanceOfXMeeds)
+        || 0;
+    },
+    yearlyRewardedMeeds() {
+      if (this.xMeedRewardInfo) {
+        if (this.xMeedRewardInfo.fixedPercentage && !this.xMeedRewardInfo.fixedPercentage.isZero()) {
+          return new BigNumber(this.rewardedMeedPerMinute.toString())
+            .multipliedBy(this.yearInMinutes)
+            .multipliedBy(this.xMeedRewardInfo.fixedPercentage.toString())
+            .dividedBy(100);
+        } else if (this.xMeedRewardInfo.allocationPoint && !this.xMeedRewardInfo.allocationPoint.isZero()) {
+          return new BigNumber(this.rewardedMeedPerMinute.toString())
+            .multipliedBy(this.yearInMinutes)
+            .multipliedBy(this.xMeedRewardInfo.allocationPoint.toString())
+            .dividedBy(this.rewardedTotalAllocationPoints.toString())
+            .dividedBy(100)
+            .multipliedBy(100 - this.rewardedTotalFixedPercentage.toNumber());
+        }
+      }
+      return new BigNumber(0);
+    },
+    apy() {
+      if (!this.meedsTotalBalanceOfXMeeds
+          || !this.yearlyRewardedMeeds
+          || this.meedsTotalBalanceOfXMeeds.isZero()
+          || this.yearlyRewardedMeeds.isZero()
+          || this.maxMeedSupplyReached) {
+        return 0;
+      }
+      return this.yearlyRewardedMeeds.dividedBy(this.meedsTotalBalanceOfXMeeds.toString()).multipliedBy(100);
+    },
+  }),
+};
+</script>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/PriceChart.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/charts/PriceChart.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,8 +21,11 @@ import PriceChart from './components/charts/PriceChart.vue';
 import TradeMeeds from './components/TradeMeeds.vue';
 import Assets from './components/Assets.vue';
 import TokenAssets from './components/assets/TokenAssets.vue';
+import EmptyTokenAssets from './components/assets/EmptyTokenAssets.vue';
 import TokenAssetTemplate from './components/assets/TokenAssetTemplate.vue';
-import TokenAsset from './components/assets/TokenAsset.vue';
+import LiquidityPoolAsset from './components/assets/LiquidityPoolAsset.vue';
+import XMeedAsset from './components/assets/XMeedAsset.vue';
+import MeedAsset from './components/assets/MeedAsset.vue';
 import DeedAssets from './components/assets/DeedAssets.vue';
 import DeedAsset from './components/assets/DeedAsset.vue';
 import MeedsInfo from './components/MeedsInfo.vue';
@@ -34,8 +37,11 @@ const components = {
   'deeds-trade-meeds': TradeMeeds,
   'deeds-assets': Assets,
   'deeds-token-assets': TokenAssets,
-  'deeds-token-asset': TokenAsset,
+  'deeds-empty-token-assets': EmptyTokenAssets,
   'deeds-token-asset-template': TokenAssetTemplate,
+  'deeds-liquidity-pool-asset': LiquidityPoolAsset,
+  'deeds-x-meed-asset': XMeedAsset,
+  'deeds-meed-asset': MeedAsset,
   'deeds-deed-assets': DeedAssets,
   'deeds-deed-asset': DeedAsset,
   'deeds-meeds-info': MeedsInfo,

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/Stake.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/Stake.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeDeeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeDeeds.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeGovernance.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeGovernance.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeMeeds.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeMeeds.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -150,12 +150,15 @@
                 max-height="17"
                 tile />
               <template v-else>
-                {{ meedsBalanceNoDecimals }}
-                <deeds-contract-address
-                  :address="meedAddress"
-                  :button-top="-2"
-                  label="MEED"
-                  token />
+                <deeds-number-format
+                  :value="meedsBalance"
+                  :fractions="2">
+                  <deeds-contract-address
+                    :address="meedAddress"
+                    :button-top="-2"
+                    label="MEED"
+                    token />
+                </deeds-number-format>
               </template>
             </v-list-item-subtitle>
           </v-list-item-content>
@@ -185,12 +188,15 @@
                   <div
                     v-bind="attrs"
                     v-on="on">
-                    {{ xMeedsBalanceNoDecimals }}
-                    <deeds-contract-address
-                      :address="xMeedAddress"
-                      :button-top="-2"
-                      label="xMEED"
-                      token />
+                    <deeds-number-format
+                      :value="xMeedsBalance"
+                      :fractions="2">
+                      <deeds-contract-address
+                        :address="xMeedAddress"
+                        :button-top="-2"
+                        label="xMEED"
+                        token />
+                    </deeds-number-format>
                   </div>
                 </template>
                 <deeds-number-format
@@ -199,12 +205,15 @@
                   label="equivalentXMeedBalanceInMeed" />
               </v-tooltip>
               <template v-else>
-                {{ xMeedsBalanceNoDecimals }}
-                <deeds-contract-address
-                  :address="xMeedAddress"
-                  :button-top="-2"
-                  label="xMEED"
-                  token />
+                <deeds-number-format
+                  :value="xMeedsBalance"
+                  :fractions="2">
+                  <deeds-contract-address
+                    :address="xMeedAddress"
+                    :button-top="-2"
+                    label="xMEED"
+                    token />
+                </deeds-number-format>
               </template>
             </v-list-item-subtitle>
           </v-list-item-content>
@@ -234,13 +243,11 @@ export default {
   computed: Vuex.mapState({
     meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,
     meedsBalance: state => state.meedsBalance,
-    meedsBalanceNoDecimals: state => state.meedsBalanceNoDecimals,
     metamaskOffline: state => state.metamaskOffline,
     meedAddress: state => state.meedAddress,
     xMeedAddress: state => state.xMeedAddress,
     xMeedsBalance: state => state.xMeedsBalance,
     xMeedsTotalSupply: state => state.xMeedsTotalSupply,
-    xMeedsBalanceNoDecimals: state => state.xMeedsBalanceNoDecimals,
     meedsPendingBalanceOfXMeeds: state => state.meedsPendingBalanceOfXMeeds,
     rewardedMeedPerMinute: state => state.rewardedMeedPerMinute,
     rewardedFunds: state => state.rewardedFunds,

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeYield.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/StakeYield.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsDrawer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsDrawer.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsStepUnstake.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsStepUnstake.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsSteps.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsSteps.vue
@@ -1,7 +1,7 @@
 <!--
  This file is part of the Meeds project (https://meeds.io/).
  
- Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/initComponents.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/initComponents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  * 
- * Copyright (C) 2020 - 2021 Meeds Association contact@meeds.io
+ * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
This change will enhance labels of Token Assets in Overview page in order to display it as an internal link with hover effect. Those labels will switch to current site tabs when clicked. In addition, this change will split a big file that lists assets into small UI components. Moreover, this commit will enhance display of assets values by displaying 2 fractions only instead of 3 in some places.