### PR TITLE
fix: Fix staked SLP equivalent fiat amount - MEED-739

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/LiquidityPoolAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/LiquidityPoolAsset.vue
@@ -62,7 +62,7 @@
     </template>
     <template #col4>
       <deeds-number-format
-        :value="lpStaked"
+        :value="userStakedEquivalentMeeds"
         :fractions="2"
         currency />
     </template>
@@ -103,7 +103,12 @@ export default {
       return this.pool && this.pool.userInfo;
     },
     lpStaked() {
-      return this.userInfo && this.userInfo.amount || 0;
+      return this.userInfo && this.userInfo.amount || new BigNumber(0);
+    },
+    userStakedEquivalentMeeds() {
+      return this.lpStaked && !this.lpStaked.isZero()
+        && this.pool.meedsBalance.mul(this.lpStaked).mul(2).div(this.pool.totalSupply)
+        || new BigNumber(0);
     },
     lpTotalSupply() {
       return this.pool && this.pool.totalSupply;


### PR DESCRIPTION
Prior to this change, the Staked SLP fiat amount was wrong. In fact, it was considered as Meed Balance instead of SLP. This change will use the equivalent MEED amount of staked SLP balance to convert it into fiat after that.