### PR TITLE
fix: Fix Equivalent fiat amount of xMeed - MEED-740

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/XMeedAsset.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/snapshot/components/assets/XMeedAsset.vue
@@ -84,8 +84,8 @@ export default {
       return this.rewardedFunds && this.xMeedAddress && this.rewardedFunds.find(fund => fund.address.toUpperCase() === this.xMeedAddress.toUpperCase());
     },
     xMeedsBalanceInMeeds() {
-      if (this.xMeedsBalance && this.xMeedsTotalSupply && !this.xMeedsTotalSupply.isZero() && this.meedsBalanceOfXMeeds) {
-        return this.xMeedsBalance.mul(this.meedsBalanceOfXMeeds).div(this.xMeedsTotalSupply);
+      if (this.xMeedsBalance && this.xMeedsTotalSupply && !this.xMeedsTotalSupply.isZero() && this.meedsTotalBalanceOfXMeeds) {
+        return this.xMeedsBalance.mul(this.meedsTotalBalanceOfXMeeds).div(this.xMeedsTotalSupply);
       } else {
         return 0;
       }


### PR DESCRIPTION
Prior to this change, the displayed amount in Token assets for xMeed, wasn't considering the rewards on hold. This change will include the real equivalent amount in fiat of xMeed Balance of user if the unstake operation is made right away.