### PR TITLE
fix: Fix Displayed xMeed Balance in points simulator - MEED-752

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsPointsSimulator.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/deeds/components/DeedsPointsSimulator.vue
@@ -71,7 +71,6 @@ export default {
     language: state => state.language,
     tokenLoading: state => state.tokenLoading,
     xMeedsBalance: state => state.xMeedsBalance,
-    xMeedsBalanceNoDecimals: state => state.xMeedsBalanceNoDecimals,
     dailyPoints() {
       if (!this.xMeedAmount) {
         return 0;
@@ -95,11 +94,11 @@ export default {
     },
   }),
   watch: {
-    xMeedsBalanceNoDecimals: {
+    xMeedsBalance: {
       immediate: true,
       handler() {
-        if (this.xMeedAmount === 100000 && this.xMeedsBalanceNoDecimals) {
-          this.xMeedAmount = parseInt(this.xMeedsBalanceNoDecimals);
+        if ((!this.xMeedAmount || this.xMeedAmount === 100000) && this.xMeedsBalance) {
+          this.xMeedAmount = this.$ethUtils.fromDecimals(this.xMeedsBalance, 18);
         }
       },
     },

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
@@ -224,7 +224,6 @@ const store = new Vuex.Store({
     etherBalance: null,
     meedsBalance: null,
     polygonMeedsBalance: null,
-    meedsBalanceNoDecimals: null,
     meedsRouteAllowance: null,
     meedsStakeAllowance: null,
     meedsTotalSupply: null,
@@ -236,7 +235,6 @@ const store = new Vuex.Store({
     meedsPendingBalanceOfXMeeds: null,
     now: Date.now(),
     xMeedsBalance: null,
-    xMeedsBalanceNoDecimals: null,
     pointsBalance: null,
     ownedNfts: null,
     selectedFiatCurrency,
@@ -313,8 +311,6 @@ const store = new Vuex.Store({
       i18n.locale = language.indexOf('fr') === 0 ? 'fr' : 'en';
       localStorage.setItem('deeds-selectedLanguage', state.language);
       initializeVueApp(language);
-      state.meedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.meedsBalance, 2, state.language);
-      state.xMeedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.xMeedsBalance, 2, state.language);
     },
     setEtherBalance(state, etherBalance) {
       state.etherBalance = etherBalance;
@@ -324,7 +320,6 @@ const store = new Vuex.Store({
     },
     setMeedsBalance(state, meedsBalance) {
       state.meedsBalance = meedsBalance;
-      state.meedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.meedsBalance, 2, state.language);
     },
     setPolygonMeedsBalance(state, balance) {
       state.polygonMeedsBalance = balance;
@@ -334,7 +329,7 @@ const store = new Vuex.Store({
     },
     setXMeedsBalance(state, xMeedsBalance) {
       state.xMeedsBalance = xMeedsBalance;
-      state.xMeedsBalanceNoDecimals = ethUtils.computeTokenBalanceNoDecimals(state.xMeedsBalance, 2, state.language);
+      state.loadingXMeedsBalance = false;
     },
     loadPointsPeriodically() {
       window.setInterval(() => this.commit('loadPointsBalance'), 20000);

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsStepUnstake.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsStepUnstake.vue
@@ -71,7 +71,6 @@ export default {
     language: state => state.language,
     etherBalance: state => state.etherBalance,
     xMeedsBalance: state => state.xMeedsBalance,
-    xMeedsBalanceNoDecimals: state => state.xMeedsBalanceNoDecimals,
     provider: state => state.provider,
     xMeedContract: state => state.xMeedContract,
     transactionGas: state => state.transactionGas,
@@ -84,6 +83,9 @@ export default {
     },
     disabledUnstakeButton() {
       return !this.unstakeAmount || !Number(this.unstakeAmount) || !this.isUnstakeAmountValid || this.sendingUnstake;
+    },
+    xMeedsBalanceNoDecimals() {
+      return this.xMeedsBalance && this.$ethUtils.computeTokenBalanceNoDecimals(this.xMeedsBalance, 2, this.language) || 0;
     },
     hasSufficientGas() {
       if (!this.unstakeAmount) {

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsSteps.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/stake/components/drawer/StakeMeedsSteps.vue
@@ -22,7 +22,7 @@
     vertical
     flat>
     <v-stepper-step
-      :complete="meedsBalanceNoDecimals > 0"
+      :complete="hasMeeds"
       editable
       step="1">
       {{ $t('approveMeeds') }}
@@ -41,7 +41,7 @@
         class="mb-12"
         flat>
         <v-card-text>
-          {{ $t('approveMeedsDescription', {0: meedsBalanceNoDecimals}) }}
+          {{ $t('approveMeedsDescription', {0: meedsBalanceToDisplay}) }}
           <v-text-field
             v-model="allowance"
             :rules="allowanceValueValidator"
@@ -153,7 +153,6 @@ export default {
     language: state => state.language,
     etherBalance: state => state.etherBalance,
     meedsBalance: state => state.meedsBalance,
-    meedsBalanceNoDecimals: state => state.meedsBalanceNoDecimals,
     meedsStakeAllowance: state => state.meedsStakeAllowance,
     xMeedsTotalSupply: state => state.xMeedsTotalSupply,
     meedsBalanceOfXMeeds: state => state.meedsBalanceOfXMeeds,
@@ -239,8 +238,11 @@ export default {
     isStakeAmountValid() {
       return !this.stakeAmount || (this.isStakeAmountNumeric && this.isStakeAmountLessThanMax && this.hasSufficientGas);
     },
-    maxMeedsBalanceNoDecimals() {
-      return this.$ethUtils.fromDecimals(this.meedsBalance, 18);
+    hasMeeds() {
+      return this.meedsBalance && !this.meedsBalance.isZero();
+    },
+    meedsBalanceToDisplay() {
+      return this.meedsBalance && this.$ethUtils.computeTokenBalanceNoDecimals(this.meedsBalance, 2, this.language) || 0;
     },
     maxMeedsAllowanceNoDecimals() {
       return this.$ethUtils.fromDecimals(this.meedsStakeAllowance, 18);
@@ -249,7 +251,7 @@ export default {
       return [
         () => !!this.hasSufficientGas || this.$t('insufficientTransactionFee'),
         () => !!this.isAllowanceValueNumeric || this.$t('valueMustBeNumeric'),
-        () => !!this.isAllowanceLessThanMax || this.$t('valueMustBeLessThan', {0: this.maxMeedsBalanceNoDecimals}),
+        () => !!this.isAllowanceLessThanMax || this.$t('valueMustBeLessThan', {0: this.meedsBalanceToDisplay}),
       ];
     },
     stakeAmountValidator() {


### PR DESCRIPTION
Prior to this change, the displayed xMeeds balance in points simulator isn't the same as real xMeed Balance, which is due to parsing integer that has a different result switch user language. This change will initialize Points simulator using the xMeed balance without language conversion of amount.