### PR TITLE
fix: Fix Character Encoding of I18N files - MEED-753

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/main.js
@@ -897,7 +897,7 @@ function initializeVueApp(language) {
         .filter(Boolean)
         .reduce((obj, line) => {
           const pair = line.split(/=(.*)/s);
-          obj[pair[0]] = pair[1];
+          obj[pair[0]] = pair[1].replace( /\\u([a-fA-F0-9]{4})/g, (g, m1) => String.fromCharCode(parseInt(m1, 16)));
           return obj;
         }, {});
 


### PR DESCRIPTION
Prior to this change, the Frensh labels are displayed with encoded UTF-8 characters. This change will decode the UTF-8 character after retrieving the keys from Backend.