### PR TITLE
fix: Fix Date Selection on Meed Price Chart - MEED-1014

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/static/css/deeds.css
+++ b/deeds-dapp-webapp/src/main/webapp/static/css/deeds.css
@@ -56,6 +56,7 @@ html {
 .priceChartPeriodSelector {
   position: absolute;
   top: 0;
+  z-index: 1;
   width: 100%;
 }
 


### PR DESCRIPTION
Prior to this change, the period selection on Token Price Chart was hidden due to chart canvas position absolute. This change will add a z-index to the links of period selection to make it on top of Chart Canvas.