### PR TITLE
fix: Update sushi link used in farm tab - MEED-1456 - Meeds-io/MIPs#48

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/main.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/main.js
@@ -519,7 +519,7 @@ const store = new Vuex.Store({
           }
 
           if (state.validNetwork) {
-            state.addSushiswapLiquidityLink = `https://app.sushi.com/add/ETH/${state.meedAddress}?chainId=${state.networkId}`;
+            state.addSushiswapLiquidityLink = `https://sushi.com/earn/eth:${state.sushiswapPairAddress}/add`;
             const networkChanged = previousNetworkId && previousNetworkId !== state.networkId;
             this.commit('setAddress', networkChanged);
           } else {


### PR DESCRIPTION
This change will update the sushi link to the newest one.