### PR TITLE
feat: Add the footer for all pages - MEED-1753 - Meeds-io/MIPs#48

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/static/html/about-us.html
+++ b/deeds-dapp-webapp/src/main/webapp/static/html/about-us.html
@@ -139,7 +139,7 @@
             {{ $t('afterTheMintingPeriod.descriptionPart2') }}
           </v-card-subtitle>
         </div>
-        <v-img src="images/logo-m-grand.svg" alt="" width="350px" class="logo-m" />
+        <v-img src="images/logo-m-grand.svg" alt="" width="350px" class="logo-m hidden-md-and-down" />
       </div>
     </v-card>
   </div>

--- a/deeds-dapp-webapp/src/main/webapp/static/html/whitepaper.html
+++ b/deeds-dapp-webapp/src/main/webapp/static/html/whitepaper.html
@@ -13,7 +13,7 @@
           <v-card-subtitle class="dark-grey-color title font-weight-normal py-2" v-html="$t('whitepaper.descriptionPart5', {0:'<strong>', 1: '</strong>'})" />
           <v-card-subtitle class="dark-grey-color title font-weight-normal py-2" v-html="$t('whitepaper.descriptionPart6', {0:'<strong>', 1: '</strong>'})" />
         </div>
-        <v-img src="images/logo-m-grand.svg" alt="" width="470px" class="logo-m" />
+        <v-img src="images/logo-m-grand.svg" alt="" width="470px" class="logo-m hidden-md-and-down" />
       </div>
       <div class=" d-flex justify-center pt-3 pb-md-7">
         <v-btn

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/layout/components/Footer.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/layout/components/Footer.vue
@@ -93,8 +93,6 @@
             <span class="font-size-normal font-weight-black text-sub-title text-uppercase mb-3">{{ $t('meedDAO') }}</span>
             <a
               :href="`${whitepaperLink}`"
-              target="_blank"
-              rel="nofollow noreferrer noopener"
               class="text-sub-title no-decoration my-2">
               {{ $t('whitePaper') }}
             </a>


### PR DESCRIPTION
This change will remove the display of the Meeds icon when using a tablet or mobile device. It will also open the link of the white paper, displayed in the footer, in the same tab.