### PR TITLE
fix: Delay Retrieving Data from ES in startup - MEED-1897

### DIFF
--- a/deeds-dapp-common/src/main/java/io/meeds/deeds/scheduling/task/ListenerEventTriggerTask.java
+++ b/deeds-dapp-common/src/main/java/io/meeds/deeds/scheduling/task/ListenerEventTriggerTask.java
@@ -33,7 +33,7 @@ public class ListenerEventTriggerTask {
   @Autowired
   private ListenerService     listenerService;
 
-  @Scheduled(fixedDelay = 10, timeUnit = TimeUnit.SECONDS, initialDelay = 30)
+  @Scheduled(fixedDelay = 10, timeUnit = TimeUnit.SECONDS, initialDelay = 60)
   public synchronized void triggerEvents() {
     try {
       listenerService.triggerElasticSearchEvents();

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/LeaseBlockchainTransactionCheckTask.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/LeaseBlockchainTransactionCheckTask.java
@@ -43,7 +43,7 @@ public class LeaseBlockchainTransactionCheckTask {
   @Autowired
   private BlockchainService   blockchainService;
 
-  @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+  @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES, initialDelay = 1)
   public void checkPendingLeases() {
     List<DeedTenantLease> pendingLeases = leaseService.getPendingTransactions();
     int pendingLeasesSize = pendingLeases.size();

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/MeedsExchangeTask.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/MeedsExchangeTask.java
@@ -33,7 +33,7 @@ public class MeedsExchangeTask {
   @Autowired
   private ExchangeService     exchangeService;
 
-  @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.HOURS, initialDelay = 1)
+  @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.HOURS, initialDelay = 2)
   public void computeExchangeRate() {
     LOG.info("Start Computing MEED exchange rates");
     long start = System.currentTimeMillis();

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/RentingBlockchainMinedEventsCheckTask.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/scheduling/task/RentingBlockchainMinedEventsCheckTask.java
@@ -79,15 +79,13 @@ public class RentingBlockchainMinedEventsCheckTask {
     minedEvents.forEach(event -> {
       if (!event.isEmpty() && event instanceof EnumMap) {
         Object keyType = event.keySet().iterator().next();
-        if (keyType instanceof BlockchainLeaseStatus) {
-          BlockchainLeaseStatus status = (BlockchainLeaseStatus) keyType;
+        if (keyType instanceof BlockchainLeaseStatus status) {
           Map<BlockchainLeaseStatus, DeedLeaseBlockchainState> events =
                                                                       (Map<BlockchainLeaseStatus, DeedLeaseBlockchainState>) event;
           DeedLeaseBlockchainState deedLease = events.get(status);
           LOG.debug("Check Lease event {} happened on Blockchain contract {} .", status, deedLease);
           updateLeaseStatusFromBlockchain(status, deedLease);
-        } else if (keyType instanceof BlockchainOfferStatus) {
-          BlockchainOfferStatus status = (BlockchainOfferStatus) keyType;
+        } else if (keyType instanceof BlockchainOfferStatus status) {
           Map<BlockchainOfferStatus, DeedOfferBlockchainState> events =
                                                                       (Map<BlockchainOfferStatus, DeedOfferBlockchainState>) event;
           DeedOfferBlockchainState blockchainOffer = events.get(status);

--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/service/LeaseService.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/service/LeaseService.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -307,7 +306,7 @@ public class LeaseService {
     return leaseRepository.findByTransactionStatusInOrderByCreatedDateAsc(Arrays.asList(TransactionStatus.IN_PROGRESS))
                           .stream()
                           .filter(lease -> !CollectionUtils.isEmpty(lease.getPendingTransactions()))
-                          .collect(Collectors.toList());
+                          .toList();
   }
 
   public void transferDeedOwnership(String newOnwer, long nftId) throws UnauthorizedOperationException {

--- a/deeds-dapp-service/src/test/java/io/meeds/deeds/web/filter/TenantPlaceholderRequestDispatcherFilterTest.java
+++ b/deeds-dapp-service/src/test/java/io/meeds/deeds/web/filter/TenantPlaceholderRequestDispatcherFilterTest.java
@@ -58,6 +58,8 @@ class TenantPlaceholderRequestDispatcherFilterTest {
   @BeforeEach
   void before() throws ServletException {
     dispatcherFilter = new TenantPlaceholderRequestDispatcherFilter() {
+      private static final long serialVersionUID = 4367082767921658504L;
+
       @Override
       public void init(FilterConfig filterConfig) throws ServletException {
         this.tenantService = tenantServiceMock;


### PR DESCRIPTION
Prior to this change, when starting Builders server, the ES is not ready yet and returns 503 HTTP code. This change will delay the access to ES lately in startup phase on cron jobs.