### PR TITLE
fix: Fix Random Long Test Running

### DIFF
--- a/deeds-dapp-common/src/test/java/io/meeds/deeds/service/AuthorizationCodeServiceTest.java
+++ b/deeds-dapp-common/src/test/java/io/meeds/deeds/service/AuthorizationCodeServiceTest.java
@@ -56,6 +56,20 @@ class AuthorizationCodeServiceTest {
 
   private static final String      DATA  = "data";
 
+  private static SecureRandom secureRandomCodeGenerator;
+
+  static {
+    try {
+      secureRandomCodeGenerator = SecureRandom.getInstance("SHA1PRNG");
+    } catch (NoSuchAlgorithmException e) {
+      try {
+        secureRandomCodeGenerator = SecureRandom.getInstanceStrong();
+      } catch (NoSuchAlgorithmException e1) {
+        throw new IllegalStateException("Error retrieving a SecureRandom Strong Instance", e1);
+      }
+    }
+  }
+
   private String                   key;
 
   @MockBean
@@ -66,7 +80,7 @@ class AuthorizationCodeServiceTest {
 
   @BeforeEach
   void setup() throws NoSuchAlgorithmException {
-    this.key = String.valueOf(SecureRandom.getInstanceStrong().nextInt(1000000));
+    this.key = String.valueOf(secureRandomCodeGenerator.nextInt(1000000));
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, a Test using Strong SecureRandom instance takes a lot of time (1 hour) in release in CI/CD. This change will attempt to make the instance re-used for different tests run to optimize tests execution time.