### PR TITLE
feat: Fix '\' character when using empty labels in crowdin - MEED-2001 - Meeds-io/MIPs#48 

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/main-static.js
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/main-static.js
@@ -119,11 +119,13 @@ function initializeVueApp(lang) {
               obj[pair[0]] = decodeURIComponent(pair[1]
                 ?.replace( /\\u00([a-fA-F0-9]{2})/g, '%$1')
                 ?.replace( /\\[uU]([a-fA-F0-9]{4})/g, (g, m1) => String.fromCharCode(parseInt(m1, 16)))
-                ?.replace(/\\n/g, '\n'));
+                ?.replace(/\\n/g, '\n'))
+                ?.replace(/\\/g,'');
             } catch (e) {
               obj[pair[0]] = pair[1]
                 ?.replace( /\\[uU]([a-fA-F0-9]{4})/g, (g, m1) => String.fromCharCode(parseInt(m1, 16)))
-                ?.replace(/\\n/g, '\n');
+                ?.replace(/\\n/g, '\n')
+                ?.replace(/\\/g,'');
             }
           }
           return obj;


### PR DESCRIPTION
This change will fix '\' character when using empty labels in crowdin.