### PR TITLE
fix: Fix Canonical URL Processing - MEED-2069 - Meeds-io/MIPs#48

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/deeds/web/filter/RequestDispatcherFilter.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/deeds/web/filter/RequestDispatcherFilter.java
@@ -71,13 +71,7 @@ public class RequestDispatcherFilter extends HttpFilter {
       if (servletPath.endsWith("/")) {
         String servletPathCanonical = servletPath.substring(0, servletPath.length() - 1);
         if (DAPP_PATHS.contains(servletPathCanonical) || STATIC_PATHS.contains(servletPathCanonical)) {
-          String requestURL = request.getRequestURL().toString();
-          if (StringUtils.isNotBlank(request.getHeader("x-forwarded-host"))) {
-            requestURL = requestURL.substring(0, requestURL.length() - 1).replace(request.getContextPath(), "");
-          } else {
-            requestURL = requestURL.substring(0, requestURL.length() - 1);
-          }
-          response.setHeader("Location", requestURL);
+          response.setHeader("Location", servletPathCanonical);
           response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
           return;
         }


### PR DESCRIPTION
Prio to this change when requesting URL https://www.meeds.io/tour/ a bad Response is retrieved from server. This change will allow server to answer with a HTTP 301 Redirection to delete the '/'  at the end of the URL.