### PR TITLE
fix: Change the rewards info for exo and rainbow partners - MEED-2669 - meeds-io/MIP#62 

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/card/HubCard.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/card/HubCard.vue
@@ -68,15 +68,15 @@
               {{ hubUsers }}
             </div>
           </div>
-          <div v-if="hubRewardsPerWeek" class="d-flex align-center justify-center ms-10">
+          <div v-if="hubRewards" class="d-flex align-center justify-center ms-10">
             <v-img 
               :src="`${parentLocation}/static/images/meed_circle.webp`"
               class="me-2"
               width="25px"
               height="25px" />
             <div class="text-light-color d-flex font-weight-normal">
-              {{ hubRewardsPerWeek }}K
-              <span class="ms-2 text-no-wrap">Ɱ / {{ $t('week') }}</span>
+              {{ hubRewards }}K
+              <span class="ms-2 text-no-wrap">Ɱ / {{ hubRewardsPeriodicity }}</span>
             </div>
           </div>
         </div>
@@ -185,8 +185,11 @@ export default {
     hubUrl() {
       return this.hub?.hubUrl;
     },
-    hubRewardsPerWeek() {
-      return this.hub?.rewardsPerWeek / 1000;
+    hubRewards() {
+      return this.hub?.rewardsPerWeek / 1000 || this.hub?.rewardsPerMonth / 1000;
+    },
+    hubRewardsPeriodicity() {
+      return this.hub?.rewardsPerWeek ? this.$t('week') : (this.hub?.rewardsPerMonth && this.$t('month'));
     },
     hubWebsiteUrl() {
       return this.hub?.websiteUrl;

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/list/HubsList.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/list/HubsList.vue
@@ -121,7 +121,7 @@ export default {
         backgroundColor: '#6083B6',
         usersCount: 10000,
         hubUrl: 'https://community.exoplatform.com',
-        rewardsPerWeek: 2000,
+        rewardsPerMonth: 3000,
       },
       {
         address: '0xfefefefefefefefefefef10',
@@ -137,6 +137,7 @@ export default {
         backgroundColor: '#2c3163',
         usersCount: 78,
         hubUrl: 'https://rainbowpartners.meeds.io/',
+        rewardsPerWeek: 800,
       },
     ],
     upcomingHubs: [


### PR DESCRIPTION
This fix will change the rewards info for exo and rainbow partners.