### PR TITLE
fix: Fix Hubs Card Reward margin -MEED-2668

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/card/HubCard.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/card/HubCard.vue
@@ -68,7 +68,7 @@
               {{ hubUsers }}
             </div>
           </div>
-          <div v-if="hubRewards" class="d-flex align-center justify-center ms-10">
+          <div v-if="hubRewards" class="d-flex align-center justify-center ms-auto">
             <v-img 
               :src="`${parentLocation}/static/images/meed_circle.webp`"
               class="me-2"


### PR DESCRIPTION
This change will align Hub Rewards to the right.