### PR TITLE
fix: Fix the hub title display when it is longer than the card's width - MEED-2954 - meeds-io/MIP#102 

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/HubCard.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/HubCard.vue
@@ -46,9 +46,9 @@
       </v-card>
       <div class="d-flex flex-column pt-2 px-4 pb-4">
         <div class="ms-10 ps-15">
-          <span class="text-h6 font-weight-bold text-no-wrap">
+          <div class="text-h6 font-weight-bold text-truncate">
             {{ hubName }}
-          </span>
+          </div>
         </div>
         <v-card 
           height="50px"


### PR DESCRIPTION
This change will fix the hub title display when it is longer than the card's width.