### PR TITLE
fix: Fix accessing robots.txt - MEED-3145

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/dapp/web/servlet/RobotsServlet.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/dapp/web/servlet/RobotsServlet.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -39,7 +40,8 @@ public class RobotsServlet extends HttpServlet {
 
   private static String       robotsContent;
 
-  public RobotsServlet() {
+  @Override
+  public void init() throws ServletException {
     retrieveRobotsFileContent();
   }
 
@@ -58,9 +60,9 @@ public class RobotsServlet extends HttpServlet {
   private static void retrieveRobotsFileContent() {
     String filePath;
     if (Utils.isProductionEnvironment()) {
-      filePath = "/robots_prod_env.txt"; // NOSONAR
+      filePath = "robots_prod_env.txt";
     } else {
-      filePath = "/robots_test_env.txt"; // NOSONAR
+      filePath = "robots_test_env.txt";
     }
     try {
       try (InputStream fileIs = RobotsServlet.class.getClassLoader().getResourceAsStream(filePath)) {


### PR DESCRIPTION
Prior to this change, the robots.txt file wasn't retrieved due to added '/' character in the beginning of the file. This change will delete this character as made in other files to fix the issue.
At the same time, this will make the initialization of the Servlet using the dedicated `init` method instead of the default constructor.