### PR TITLE
fix: Disable Unit Test Hyperledger Repository - Meeds-io/MIPs#58

### DIFF
--- a/deeds-dapp-contract/pom.xml
+++ b/deeds-dapp-contract/pom.xml
@@ -154,6 +154,7 @@
     </plugins>
   </build>
 
+  <!-- Disable Unit Tests for now until Nexus Mirror is updated With reference to hyperledger Nexus
   <repositories>
     <repository>
       <id>hyperledger</id>
@@ -166,5 +167,6 @@
       </snapshots>
     </repository>
   </repositories>
+  -->
 
 </project>


### PR DESCRIPTION
This change will disable Hyperledger repository used to execute unit tests using non existing ertifacts in eXo repositories. Without this change, the dapp release fails.