### PR TITLE
fix: Avoid displaying Reward period when not present - MEED-3320 - Meeds-io/MIPs#58

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/static/i18n/messages_en.properties
+++ b/deeds-dapp-webapp/src/main/webapp/static/i18n/messages_en.properties
@@ -927,6 +927,7 @@ wom.participantsCount=Participants
 wom.recipientsCount=Recipients
 wom.achievementsCount=Achievements
 wom.actionsCount=Actions
+wom.rewards=Rewards
 wom.rewardsPer=Rewards / {0}
 wom.achievements=achievements
 wom.unkownBlockchain=Unknown blockchain

--- a/deeds-dapp-webapp/src/main/webapp/static/i18n/messages_fr.properties
+++ b/deeds-dapp-webapp/src/main/webapp/static/i18n/messages_fr.properties
@@ -926,6 +926,7 @@ wom.participantsCount=Participants
 wom.recipientsCount=Recipients
 wom.achievementsCount=Achievements
 wom.actionsCount=Actions
+wom.rewards=Rewards
 wom.rewardsPer=Rewards / {0}
 wom.achievements=achievements
 wom.unkownBlockchain=Unknown blockchain

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItemDetails.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItemDetails.vue
@@ -86,10 +86,10 @@ export default {
       return this.report?.periodType?.toLowerCase();
     },
     hubRewardsPeriod() {
-      return this.$t(`wom.${this.hubRewardsPeriodType}`);
+      return this.hubRewardsPeriodType && this.$t(`wom.${this.hubRewardsPeriodType}`);
     },
     hubRewardsPerPeriod() {
-      return this.$t('wom.rewardsPer', {0: this.hubRewardsPeriod});
+      return this.hubRewardsPeriodType && this.$t('wom.rewardsPer', {0: this.hubRewardsPeriod}) || 'wom.rewards';
     },
   }),
 };

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItemOverview.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItemOverview.vue
@@ -120,7 +120,7 @@
                   height="25">
               </v-card>
               <div class="text-truncate d-flex">
-                {{ hubTopRewardedAmountFormatted }} {{ $t('meedsSymbol') }}<span class="hidden-xs-only ms-1"> / {{ hubRewardsPeriod }}</span>
+                {{ hubTopRewardedAmountFormatted }} {{ $t('meedsSymbol') }}<span v-if="hubRewardsPeriodType" class="hidden-xs-only ms-1"> / {{ hubRewardsPeriod }}</span>
               </div>
             </div>
           </template>
@@ -205,7 +205,7 @@ export default {
       return this.report?.periodType?.toLowerCase();
     },
     hubRewardsPeriod() {
-      return this.$t(`wom.${this.hubRewardsPeriodType}`);
+      return this.hubRewardsPeriodType && this.$t(`wom.${this.hubRewardsPeriodType}`) || '';
     },
     hubTopRewardedAmount() {
       return this.report?.hubTopRewardedAmount || 0;


### PR DESCRIPTION
The Hub Report in blockchain doesn't have the information of Hub Reward Period Type. Thus, when the Hub report isn't sent by  Hub, but retrieved from blockchain only, the Hub Reward periodicity is missing. This change will consider the fact that the period type can be missing in displayed report.