### PR TITLE
fix: Fix Displayed Report Reward End Date - MEED-3383 - Meeds-io/MIPs#58

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItem.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItem.vue
@@ -131,7 +131,7 @@ export default {
       return this.report?.fromDate;
     },
     toDate() {
-      return this.report?.toDate;
+      return new Date(this.report?.toDate).getTime() - 1;
     },
     rewardId() {
       return this.report?.rewardId;


### PR DESCRIPTION
Prior to this change, the displayed report end date displays the next day at 00:00 while it should display the end date at 23:59. This change will delete a millisecond from end date to be able to display the right end date.