### PR TITLE
fix: Fix Display of Newly Joining Hub in the WoM - MEED-3386

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/card/HubCard.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/card/HubCard.vue
@@ -117,7 +117,7 @@
                   height="25"
                   class="me-2">
                 <div class="text-light-color d-flex font-weight-normal">
-                  {{ hubRewardsAmount }}
+                  {{ hubRewardsAmountFormatted }}
                   <span class="ms-2 text-no-wrap">Ɱ / {{ hubRewardsPeriod }}</span>
                 </div>
               </div>
@@ -163,7 +163,7 @@
                       height="25"
                       class="me-2">
                     <div class="text-light-color d-flex font-weight-normal">
-                      {{ hubRewardsAmount }}
+                      {{ hubRewardsAmountFormatted }}
                       <span class="ms-2 text-no-wrap">Ɱ / {{ hubRewardsPeriod }}</span>
                     </div>
                   </div>
@@ -240,7 +240,10 @@ export default {
       return this.hubRewardsPeriodType && this.$t(`wom.${this.hubRewardsPeriodType}`);
     },
     hubRewardsAmount() {
-      return this.formatNumber(this.hub?.rewardsPerPeriod);
+      return this.hub?.rewardsPerPeriod || 0;
+    },
+    hubRewardsAmountFormatted() {
+      return this.formatNumber(this.hubRewardsAmount);
     },
     hubWebsiteUrl() {
       return this.hub?.websiteUrl;


### PR DESCRIPTION
Prior to this change, when a Hub joins a WoM a display of 0 Meeds is made on Hub Card as there are no report sent yet. This change ensure to hide it when no reports.