### PR TITLE
fix: Fix Hub Connection Generated Tokens TTL Algorithm - MEED-3396

### DIFF
--- a/deeds-dapp-common/src/main/java/io/meeds/deeds/common/service/HubService.java
+++ b/deeds-dapp-common/src/main/java/io/meeds/deeds/common/service/HubService.java
@@ -100,13 +100,6 @@ public class HubService {
 
   private SecureRandom        secureRandomCodeGenerator;
 
-  /**
-   * 10 minutes by default for Token validity
-   */
-  private static final long   MAX_GENERATED_TOKENS_LT    = 1000l *
-      Integer.parseInt(System.getProperty("meeds.hub.maxTokenLiveTimeSeconds",
-                                          "600"));
-
   @Autowired
   private TenantService       tenantService;
 
@@ -136,6 +129,9 @@ public class HubService {
    */
   @Value("${meeds.hub.maxTokensPerClientIp:100}")
   private int                      maxTokensPerClientIp;
+
+  @Value("${meeds.hub.maxTokenLiveTimeSeconds:600}")
+  private int                      maxTokenLiveTime;
 
   private Map<String, TokenDetail> tokens                     = new ConcurrentHashMap<>();
 
@@ -791,7 +787,7 @@ public class HubService {
   }
 
   private void cleanInvalidTokens() {
-    tokens.entrySet().removeIf(entry -> (entry.getValue().createdTime - System.currentTimeMillis()) > MAX_GENERATED_TOKENS_LT);
+    tokens.entrySet().removeIf(entry -> (System.currentTimeMillis() - entry.getValue().createdTime) / 1000l >= maxTokenLiveTime);
   }
 
   private long countTokens(String clientIp) {

--- a/deeds-dapp-common/src/test/java/io/meeds/deeds/common/service/HubServiceTest.java
+++ b/deeds-dapp-common/src/test/java/io/meeds/deeds/common/service/HubServiceTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -101,11 +101,14 @@ import io.meeds.wom.api.model.HubUpdateRequest;
 import io.meeds.wom.api.model.WomConnectionRequest;
 import io.meeds.wom.api.model.WomDisconnectionRequest;
 
+import lombok.SneakyThrows;
+
 @SpringBootTest(classes = {
   HubService.class,
 })
 @TestPropertySource(properties = {
   "meeds.hub.maxTokensPerClientIp=2",
+  "meeds.hub.maxTokenLiveTimeSeconds=1",
 })
 @ExtendWith(MockitoExtension.class)
 class HubServiceTest {
@@ -570,6 +573,7 @@ class HubServiceTest {
   }
 
   @Test
+  @SneakyThrows
   void generateToken() {
     String token = hubService.generateToken(CLIENT_IP);
     assertNotNull(token);
@@ -581,6 +585,10 @@ class HubServiceTest {
     assertNotNull(token3);
     assertNotEquals(token3, token);
     assertNotEquals(token3, token2);
+
+    Thread.sleep(1000);
+    String token4 = hubService.generateToken(CLIENT_IP);
+    assertNotNull(token4);
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, the tokens cleanup wasn't made due to inverted order of the minus operator params (Current Time - Past time) instead of (Past time - Current tiem). This change will ensure to consider testing the cleanup algorithm to ensure that it works as expected.