### PR TITLE
fix: Display of Report Detail in Firefox - MEED-3401 - Meeds-io/meeds#1681

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportDistributionRateFormula.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportDistributionRateFormula.vue
@@ -47,8 +47,8 @@
           =
         </mo>
         <ms
-          v-sanitized-html="$t('uem.formulaDistributionRate', {0: `<span class='font-weight-bold me-1 ${distributionRateColor}--text'>${distributionRatePercentage}</span>`})"
           class="d-flex font-weight-bold">
+          <div v-sanitized-html="$t('uem.formulaDistributionRate', {0: `<span class='font-weight-bold me-1 ${distributionRateColor}--text'>${distributionRatePercentage}</span>`})"></div>
         </ms>
       </mrow>
     </math>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportDistributionSpreadFormula.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportDistributionSpreadFormula.vue
@@ -46,9 +46,8 @@
         <mo stretchy="true" class="font-weight-bold">
           =
         </mo>
-        <ms
-          v-sanitized-html="$t('uem.formulaDistributionSpread', {0: `<span class='font-weight-bold me-1 ${distributionSpreadColor}--text'>${distributionSpreadPercentage}</span>`})"
-          class="d-flex font-weight-bold">
+        <ms class="d-flex font-weight-bold">
+          <div v-sanitized-html="$t('uem.formulaDistributionSpread', {0: `<span class='font-weight-bold me-1 ${distributionSpreadColor}--text'>${distributionSpreadPercentage}</span>`})"></div>
         </ms>
       </mrow>
     </math>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportEngagementFormula.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportEngagementFormula.vue
@@ -43,11 +43,11 @@
         <mo stretchy="true" class="font-weight-bold">
           =
         </mo>
-        <ms
-          v-sanitized-html="$t('uem.formulaEngagementAverage', {
-            0: `<span class='font-weight-bold me-1 ${engagementScoreColor}--text'>${engagementScorePercentage}</span>`
-          })"
-          class="d-flex font-weight-bold">
+        <ms class="d-flex font-weight-bold">
+          <div
+            v-sanitized-html="$t('uem.formulaEngagementAverage', {
+              0: `<span class='font-weight-bold me-1 ${engagementScoreColor}--text'>${engagementScorePercentage}</span>`
+            })"></div>
         </ms>
       </mrow>
     </math>

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportFormulaComputingResult.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportFormulaComputingResult.vue
@@ -21,7 +21,7 @@
 <template>
   <div class="d-flex flex-column">
     <div class="d-flex flex-column fa-lg">
-      <math class="my-1">
+      <math display="block" class="my-1">
         <mrow>
           <msub>
             <mi>{{ $t('uem.hub') }}</mi>
@@ -40,14 +40,14 @@
           <mi>{{ $t('uem.rewardAmount') }}</mi>
         </mrow>
       </math>
-      <math class="my-1">
+      <math display="block" class="my-1">
         <mrow>
           <mo stretchy="true" class="font-weight-bold">
             =
           </mo>
         </mrow>
       </math>
-      <math class="my-1">
+      <math display="block" class="my-1">
         <mrow>
           <mfrac linethickness="2">
             <mn>{{ report.fixedRewardIndex }}</mn>
@@ -58,14 +58,14 @@
           <mn class="secondary--text ms-1">Ɱ</mn>
         </mrow>
       </math>
-      <math class="my-1">
+      <math display="block" class="my-1">
         <mrow>
           <mo stretchy="true" class="font-weight-bold">
             =
           </mo>
         </mrow>
       </math>
-      <math class="my-1">
+      <math display="block" class="my-1">
         <mrow>
           <mn class="info--text">{{ uemRewardPercentage }}</mn>
           <mo stretchy="true" class="font-weight-bold mx-2">*</mo>
@@ -73,7 +73,7 @@
           <mn class="secondary--text ms-1">Ɱ</mn>
         </mrow>
       </math>
-      <math class="my-1">
+      <math display="block" class="my-1">
         <mrow>
           <mo stretchy="true" class="font-weight-bold">
             =

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportMintingPower.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportMintingPower.vue
@@ -19,15 +19,20 @@
 
 -->
 <template>
-  <li>
-    <math class="my-1">
+  <li class="my-1">
+    <math>
       <mrow>
         <mi>M</mi>
         <mo stretchy="true" class="font-weight-bold">
           =
         </mo>
-        <mn class="font-weight-bold">
-          <v-chip class="px-2 py-0 rounded-circle">{{ mintingPower }}</v-chip>
+        <mn stretchy="true" class="font-weight-bold">
+          <v-card
+            width="38"
+            class="position-relative"
+            flat>
+            <v-chip class="px-2 py-0 full-width rounded-circle d-flex align-center justify-center">{{ mintingPower }}</v-chip>
+          </v-card>
         </mn>
         <mo stretchy="true" class="font-weight-bold">
           =

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItemDetailCard.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/rewards/HubRewardItemDetailCard.vue
@@ -5,7 +5,9 @@
     height="80"
     outlined
     hover>
-    <div class="my-auto d-flex align-center flex-grow-1 text-light-color">
+    <div
+      :class="dark && 'white--text' || 'text-light-color'"
+      class="my-auto d-flex align-center flex-grow-1">
       {{ $t(label) }}
     </div>
     <div class="my-auto d-flex align-center flex-grow-1">
@@ -51,6 +53,7 @@ export default {
   computed: Vuex.mapState({
     language: state => state.language,
     parentLocation: state => state.parentLocation,
+    dark: state => state.dark,
     valueFormat() {
       return this.$utils.numberFormatWithDigits(this.value, this.language);
     },


### PR DESCRIPTION
Prior to this change, the Display of Hub Report was badly aligned on FireFox only. This change will ensure to use generic CSS and HTML structure to ensure consistency between browsers.