### PR TITLE
fix: Fix UEM formula Final Score display - MEED-3538

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/HubReportFormula.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/HubReportFormula.vue
@@ -37,7 +37,9 @@
     </div>
     <div class="reset-style-box">
       <ul>
-        <deed-hub-report-engagement-score :report="report" />
+        <deed-hub-report-engagement-score
+          :reward="reward"
+          :report="report" />
         <deed-hub-report-engagement-formula
           :reward="reward"
           :report="report" />

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportEngagementScore.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportEngagementScore.vue
@@ -26,7 +26,7 @@
         <mo stretchy="true" class="font-weight-bold">
           =
         </mo>
-        <mn class="font-weight-bold">{{ report.fixedRewardIndex }}</mn>
+        <mn class="font-weight-bold">{{ report.fixedRewardIndex / reward.ew }}</mn>
         <mo stretchy="true" class="font-weight-bold">
           =
         </mo>
@@ -41,6 +41,10 @@
 export default {
   props: {
     report: {
+      type: Object,
+      default: null,
+    },
+    reward: {
       type: Object,
       default: null,
     },

--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportFormulaComputing.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/hubs/components/details/formula/ReportFormulaComputing.vue
@@ -94,7 +94,7 @@
         color="primary"
         large
         dark>
-        {{ $utils.numberFormatWithDigits(report.fixedRewardIndex, language, 2, 5) }}
+        {{ $utils.numberFormatWithDigits(report.fixedRewardIndex / reward.ew, language, 2, 5) }}
       </v-chip>
     </div>
   </div>


### PR DESCRIPTION
Prior to this change, the display of the computing result misses the `ew` (average score of all hubs). This change will fix the display by making the missing division.