### PR TITLE
fix: Fix display of Deed Card Type - MEED-5547 - Meeds-io/meeds#1851

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/owners/components/DeedsOwnersList.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/owners/components/DeedsOwnersList.vue
@@ -188,7 +188,7 @@ export default {
         const lease = this.refreshedLeases[deed.id] || {
           nftId: deed.id,
           city: this.cities[deed.cityIndex],
-          cardType: this.cardTypes[deed.cardType],
+          cardType: this.cardTypes[parseInt(deed.cardType % 4)],
           ownerAddress: this.address,
           managerAddress: this.address,
           rentedOffers: this.rentedOffers[deed.id]?.slice() || [],


### PR DESCRIPTION
Prior to this change, the deed owners tab wasn't displaying Owned Deed Card Type correctly. This change will ensure to display the correct owned deed type characteristics.