### PR TITLE
disable bottom bar on mobile

### DIFF
--- a/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/layout/components/SiteContent.vue
+++ b/deeds-dapp-webapp/src/main/webapp/vue-app/dapp/layout/components/SiteContent.vue
@@ -64,7 +64,7 @@ export default {
     staticPage: state => state.staticPage,
     isMobile: state => state.isMobile,
     mobileNavigationBar() {
-      return !this.staticPage && this.isMobile;
+      return false;//!this.staticPage && this.isMobile;
     },
   }),
   created() {


### PR DESCRIPTION
Before this change, a nav bar was displayed on mobile and on (non-static) pages of the dApp. 

This change changes this behavior, so no bottom nav is displayed on mobile.