### PR TITLE
fix: update ElasticSearchConfig to use Elasticsearch 8.14.3 Java client for cluster health check

### DIFF
--- a/deeds-dapp-common/src/main/java/io/meeds/deeds/common/elasticsearch/ElasticSearchConfig.java
+++ b/deeds-dapp-common/src/main/java/io/meeds/deeds/common/elasticsearch/ElasticSearchConfig.java
@@ -29,10 +29,10 @@ import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfigurat
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.RefreshPolicy;
-import org.springframework.data.elasticsearch.core.cluster.ClusterHealth;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
 
 @Configuration
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
@@ -78,28 +78,36 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
                                                          ElasticsearchClient elasticsearchClient) {
     ElasticsearchTemplate elasticsearchTemplate = new ElasticsearchTemplate(elasticsearchClient, elasticsearchConverter);
     elasticsearchTemplate.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
-    tryConnection(elasticsearchTemplate);
+    tryConnection(elasticsearchTemplate, elasticsearchClient);
     return elasticsearchTemplate;
   }
 
-  private void tryConnection(ElasticsearchOperations elasticsearchOperations) {
+  private void tryConnection(ElasticsearchOperations elasticsearchOperations, ElasticsearchClient elasticsearchClient) {
     int i = connectionRetry;
     while (i-- > 0) {
       int tentative = connectionRetry - i;
       try {
-        ClusterHealth elasticHealth = elasticsearchOperations.cluster().health();
-        if (elasticHealth.isTimedOut()
-            || elasticHealth.getActiveShardsPercent() < 1
-            || elasticHealth.getActiveShards() == 0
-            || !StringUtils.equalsIgnoreCase(elasticHealth.getStatus(), "green")) {
-          throw new IllegalStateException(String.format("Elasticsearch Cluster Health Check TimedOut. Active shard = '%s', Percentage = '%s', Status = '%s'",
-                                                        elasticHealth.getActiveShards(),
-                                                        elasticHealth.getActiveShardsPercent(),
-                                                        elasticHealth.getStatus()));
-        } else {
-          LOG.info("Connection established to ES after {}/{} tentatives", tentative, connectionRetry);
-          i = 0;
+        HealthResponse healthResponse = elasticsearchClient.cluster().health();
+
+        boolean timedOut = healthResponse.timedOut();
+        double activeShardsPercent = Double.parseDouble(healthResponse.activeShardsPercentAsNumber());
+        int activeShards = healthResponse.activeShards();
+        String status = healthResponse.status().jsonValue();
+
+        if (timedOut
+            || activeShardsPercent < 1
+            || activeShards == 0
+            || !StringUtils.equalsIgnoreCase(status, "green")) {
+          throw new IllegalStateException(String.format(
+            "Elasticsearch Cluster Health Check Failed. Active shards = '%s', Percentage = '%.2f', Status = '%s'",
+            activeShards,
+            activeShardsPercent,
+            status));
         }
+
+        LOG.info("Connection established to ES after {}/{} tentatives", tentative, connectionRetry);
+        i = 0;
+
       } catch (Exception e) {
         if (i == 0) {
           LOG.warn("Connection failure to ES. tentative {}/{}.", tentative, connectionRetry);

--- a/deeds-dapp-common/src/main/java/io/meeds/deeds/common/elasticsearch/ElasticSearchConfig.java
+++ b/deeds-dapp-common/src/main/java/io/meeds/deeds/common/elasticsearch/ElasticSearchConfig.java
@@ -16,6 +16,7 @@
 package io.meeds.deeds.common.elasticsearch;
 
 import java.time.Duration;
+import java.io.InputStream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -32,7 +33,12 @@ import org.springframework.data.elasticsearch.core.RefreshPolicy;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.cluster.HealthResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
@@ -87,22 +93,35 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
     while (i-- > 0) {
       int tentative = connectionRetry - i;
       try {
-        HealthResponse healthResponse = elasticsearchClient.cluster().health();
+        // Create a temporary low-level client directly from your ES URL
+        RestClient restClient = RestClient.builder(
+            new org.apache.http.HttpHost(
+                esUrl.split("//")[1].split(":")[0],
+                Integer.parseInt(esUrl.split(":")[2])
+            )
+        ).build();
 
-        boolean timedOut = healthResponse.timedOut();
-        double activeShardsPercent = Double.parseDouble(healthResponse.activeShardsPercentAsNumber());
-        int activeShards = healthResponse.activeShards();
-        String status = healthResponse.status().jsonValue();
+        Request request = new Request("GET", "/_cluster/health");
+        Response response = restClient.performRequest(request);
 
-        if (timedOut
-            || activeShardsPercent < 1
-            || activeShards == 0
-            || !StringUtils.equalsIgnoreCase(status, "green")) {
-          throw new IllegalStateException(String.format(
-            "Elasticsearch Cluster Health Check Failed. Active shards = '%s', Percentage = '%.2f', Status = '%s'",
-            activeShards,
-            activeShardsPercent,
-            status));
+        try (InputStream is = response.getEntity().getContent()) {
+          JsonNode node = new ObjectMapper().readTree(is);
+
+          boolean timedOut = node.get("timed_out").asBoolean();
+          double activeShardsPercent = node.get("active_shards_percent_as_number").asDouble();
+          int activeShards = node.get("active_shards").asInt();
+          String status = node.get("status").asText();
+
+          if (timedOut
+              || activeShardsPercent < 1
+              || activeShards == 0
+              || !StringUtils.equalsIgnoreCase(status, "green")) {
+            throw new IllegalStateException(String.format(
+                "Elasticsearch Cluster Health Check Failed. Active shards = '%s', Percentage = '%.2f', Status = '%s'",
+                activeShards,
+                activeShardsPercent,
+                status));
+          }
         }
 
         LOG.info("Connection established to ES after {}/{} tentatives", tentative, connectionRetry);


### PR DESCRIPTION
- Replaced deprecated Spring Data Elasticsearch cluster health call with the official `ElasticsearchClient.cluster().health()` method.
- Avoids response decoding errors encountered with the Elasticsearch 8.x cluster health endpoint.
- Added retry logic for the cluster health check, leveraging typed `HealthResponse` fields (`timedOut`, `activeShards`, `status`) for more reliable status validation.
- Ensures stable connection initialization when connecting to Elasticsearch 8.14.3 backend.
- This update fixes issues related to decoding cluster health responses and enables smooth, robust integration with Elasticsearch 8.x versions.