### PR TITLE
feat: Improve Log Verbosity when Blockchain Connection Fails

### DIFF
--- a/deeds-dapp-service/src/main/java/io/meeds/dapp/scheduling/task/MeedAssetsMetricTask.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/dapp/scheduling/task/MeedAssetsMetricTask.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.web3j.protocol.exceptions.ClientConnectionException;
 
 import io.meeds.dapp.service.MeedAssetsMetricsService;
 
@@ -39,7 +40,12 @@ public class MeedAssetsMetricTask {
       meedAssetsMetricsService.computeMeedAssetsMetrics();
       LOG.info("End Computing Meed Assets Metrics in {}ms", System.currentTimeMillis() - start);
     } catch (Exception e) {
-      LOG.warn("An error occurred while computing Meed Assets Metrics", e);
+      if (!LOG.isDebugEnabled()
+          && (e instanceof ClientConnectionException || e.getCause() instanceof ClientConnectionException)) {
+        LOG.warn("An error occurred while computing Meed Assets Metrics: {}", e.getMessage());
+      } else {
+        LOG.warn("An error occurred while computing Meed Assets Metrics", e);
+      }
     }
   }
 

--- a/deeds-dapp-service/src/main/java/io/meeds/dapp/scheduling/task/MeedTokenMetricTask.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/dapp/scheduling/task/MeedTokenMetricTask.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.web3j.protocol.exceptions.ClientConnectionException;
 
 import io.meeds.dapp.service.MeedTokenMetricService;
 
@@ -39,7 +40,12 @@ public class MeedTokenMetricTask {
       meedTokenMetricService.computeTokenMetrics();
       LOG.info("End Computing circulating supply in {}ms", System.currentTimeMillis() - start);
     } catch (Exception e) {
-      LOG.warn("An error occurred while computing circulating supply", e);
+      if (!LOG.isDebugEnabled()
+          && (e instanceof ClientConnectionException || e.getCause() instanceof ClientConnectionException)) {
+        LOG.warn("An error occurred while computing circulating supply: {}", e.getMessage());
+      } else {
+        LOG.warn("An error occurred while computing circulating supply", e);
+      }
     }
   }
 

--- a/deeds-dapp-service/src/main/java/io/meeds/dapp/web/rest/HubController.java
+++ b/deeds-dapp-service/src/main/java/io/meeds/dapp/web/rest/HubController.java
@@ -198,7 +198,11 @@ public class HubController {
       LOG.info(WOM_CONNECTION_LOG_MESSAGE, e.getMessage());
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getErrorCode());
     } catch (Exception e) {
-      LOG.warn("An unkown error happened when trying to process the refresh Hub request", e);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("An unkown error happened when trying to process the refresh Hub request", e);
+      } else {
+        LOG.warn("An unkown error happened when trying to process the refresh Hub request: {}", e.getMessage());
+      }
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(WOM_UNKNOWN_ERROR_MESSAGE + e.getMessage());
     }
   }


### PR DESCRIPTION
Prior to this change, when a Blockchain connection error happens during Server Runtime, the Scheduled Jobs will continue to log ERROR Level which pollutes Server Logs. This change will avoid this by changing the Log Level switch number of connection errors.